### PR TITLE
Only show obelisk groups that have some active obelisks

### DIFF
--- a/Source/index.html
+++ b/Source/index.html
@@ -241,6 +241,9 @@
 				<div class="panzoom noselect" id="ruin-map">
 					&nbsp;
 				</div>
+				<span id="hide-empty-groups" class="noselect">
+					<input id="check-only-show" type="checkbox" checked /><label for="check-only-show">Hide groups without active obelisks</label>
+				</span>
 			</div>
 
 

--- a/Source/ruins.css
+++ b/Source/ruins.css
@@ -213,6 +213,12 @@ button {
   background-image: url('images/zoom-reset.png');
 }
 
+#hide-empty-groups {
+  float: right;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
 
 #edbearing {
   background-image: url('images/logo-edbearing.png');

--- a/Source/scripts/guardian.ruins.js
+++ b/Source/scripts/guardian.ruins.js
@@ -47,9 +47,11 @@ my.getRuin = function (setOptions) {
 			}
 
 			this.showAll = function(){
-				//Show those that have been added
+				//Show those that have been added and have some active obelisks
 				$.each( ruins.ruinData.groups , function( designation, value ) {
-				  $('.ruin-group-' + designation).show();
+					if (value.some(_ => _.active)) {
+						$('.ruin-group-' + designation).show();
+					}
 				});
 
 

--- a/Source/scripts/guardian.ruins.js
+++ b/Source/scripts/guardian.ruins.js
@@ -46,10 +46,10 @@ my.getRuin = function (setOptions) {
 
 			}
 
-			this.showAll = function(){
+			this.showAll = function(showEmptyGroups = false){
 				//Show those that have been added and have some active obelisks
 				$.each( ruins.ruinData.groups , function( designation, value ) {
-					if (value.some(_ => _.active)) {
+					if (showEmptyGroups || value.some(_ => _.active)) {
 						$('.ruin-group-' + designation).show();
 					}
 				});

--- a/Source/scripts/ruins.js
+++ b/Source/scripts/ruins.js
@@ -511,6 +511,11 @@ function prepMapUI(completed) {
 		showSystems();
 	});
 
+	$("#check-only-show").change(function () {
+		// hide all groups, then re-show including groups without active obelisks or not
+		window.ruins.hideAllForType();
+		window.ruins.showAll(!this.checked);
+	});
 
 	$("#edbearing").on('click', function () {
 		var desc = window.currentRuin.ruinTypeName + ' Ruin at ' + [

--- a/Source/scripts/ruins.js
+++ b/Source/scripts/ruins.js
@@ -805,11 +805,16 @@ function ruinSelected(ruinId) {
 		window.currentRuin = ruinSystem;
 
 		//Update map header info
+		var ruinType = window.currentRuin.ruinTypeName;
+		if (window.currentRuin.frontierID > 0) {
+			// if known, show the Ruins # in the header too
+			ruinType += `, Ruins #${window.currentRuin.frontierID}`
+		}
 		$('#map_heading h1').text([
 			window.systems[systemId].systemName,
 			window.currentRuin.bodyName,
 			window.currentRuin.coordinates.join(', ')
-		].join(' | ') + ' (' + window.currentRuin.ruinTypeName + ')');
+		].join(' | ') + ' (' + ruinType + ')');
 
 		//And show
 		showNotice('Opening Ruin Map', true);


### PR DESCRIPTION
When loading the map, all obelisk groups are initially hidden, then made visible. This change means we only show groups that are known to have >0 obelisks.

Verified correct against manual inspections of 8 sites:
* Col 173 Sector BX-I c10-7, B 2
* Col 173 Sector LJ-F c12-0, B 7
* Synuefe CE-R c21-6, C 1 - Ruins#1 - alpha
* Synuefe CE-R c21-6, C 1 - Ruins#2 - beta
* Synuefe CE-R c21-6, C 1 - Ruins#3 - alpha
* Synuefe ZR-I B43-10, D 2 - GR44 - alpha
* Synuefe ZR-I B43-10, D 2 - GR45 - beta
* Synuefe ZR-I B43-10, D 2 - GR46 - alpha

![image](https://user-images.githubusercontent.com/3903773/210847995-fdbe6215-1d76-4bef-a405-e5925a62f5f2.png)


2nd revision add's a checkbox that can be used to show all groups (the old behaviour):

![image](https://user-images.githubusercontent.com/3903773/211104275-e367a6c2-10f6-4de3-a9e2-4de1850847c8.png)
