### PR TITLE
Fix typo in id64

### DIFF
--- a/Source/data/getRuinList.json
+++ b/Source/data/getRuinList.json
@@ -15559,7 +15559,7 @@
                 "longitude": -67.7127,
                 "frontierID": 1,
                 "system": {
-                    "id": "15883,
+                    "id": "15883",
                     "systemName": "GRAEA HYPUE LS-S D4-81",
                     "edsmID": 49888233
                 },
@@ -15577,7 +15577,7 @@
                 "longitude": -140.3904,
                 "frontierID": 3,
                 "system": {
-                    "id": "916,
+                    "id": "916",
                     "systemName": "COL 173 SECTOR YF-N C7-5",
                     "edsmID": 24935694
                 },
@@ -15595,7 +15595,7 @@
                 "longitude": 127.4302,
                 "frontierID": 1,
                 "system": {
-                    "id": "85731250834,
+                    "id": "85731250834",
                     "systemName": "COL 173 SECTOR DM-L C8-0",
                     "edsmID": 49122569
                 },
@@ -15613,7 +15613,7 @@
                 "longitude": 23.3995,
                 "frontierID": 3,
                 "system": {
-                    "id": "85731250834,
+                    "id": "85731250834",
                     "systemName": "COL 173 SECTOR DM-L C8-0",
                     "edsmID": 49122569
                 },
@@ -15631,7 +15631,7 @@
                 "longitude": -3.7987,
                 "frontierID": 2,
                 "system": {
-                    "id": "85731250834,
+                    "id": "85731250834",
                     "systemName": "COL 173 SECTOR DM-L C8-0",
                     "edsmID": 49122569
                 },
@@ -15649,7 +15649,7 @@
                 "longitude": -128.2579,
                 "frontierID": 1,
                 "system": {
-                    "id": "85731250834,
+                    "id": "85731250834",
                     "systemName": "COL 173 SECTOR DM-L C8-0",
                     "edsmID": 49122569
                 },
@@ -15667,7 +15667,7 @@
                 "longitude": -131.6195,
                 "frontierID": 2,
                 "system": {
-                    "id": "113774610747,
+                    "id": "113774610747",
                     "systemName": "COL 173 SECTOR GM-V D2-3",
                     "edsmID": 35497248
                 },
@@ -15685,7 +15685,7 @@
                 "longitude": 121.2838,
                 "frontierID": 1,
                 "system": {
-                    "id": "113774610747,
+                    "id": "113774610747",
                     "systemName": "COL 173 SECTOR GM-V D2-3",
                     "edsmID": 35497248
                 },
@@ -15703,7 +15703,7 @@
                 "longitude": 134.9841,
                 "frontierID": 3,
                 "system": {
-                    "id": "113774610747,
+                    "id": "113774610747",
                     "systemName": "COL 173 SECTOR GM-V D2-3",
                     "edsmID": 35497248
                 },
@@ -15721,7 +15721,7 @@
                 "longitude": 50.4803,
                 "frontierID": 2,
                 "system": {
-                    "id": "113774610747,
+                    "id": "113774610747",
                     "systemName": "COL 173 SECTOR GM-V D2-3",
                     "edsmID": 35497248
                 },
@@ -15739,7 +15739,7 @@
                 "longitude": 24.0003,
                 "frontierID": 1,
                 "system": {
-                    "id": "113774610747,
+                    "id": "113774610747",
                     "systemName": "COL 173 SECTOR GM-V D2-3",
                     "edsmID": 35497248
                 },
@@ -15757,7 +15757,7 @@
                 "longitude": -0.3500,
                 "frontierID": 1,
                 "system": {
-                    "id": "128242061185403,
+                    "id": "128242061185403",
                     "systemName": "EORL AUWSY SY-Z D13-3732",
                     "edsmID": 22202599
                 },
@@ -15775,7 +15775,7 @@
                 "longitude": 52.3133,
                 "frontierID": 2,
                 "system": {
-                    "id": "128242061185403,
+                    "id": "128242061185403",
                     "systemName": "EORL AUWSY SY-Z D13-3732",
                     "edsmID": 22202599
                 },
@@ -15793,7 +15793,7 @@
                 "longitude": -156.1423,
                 "frontierID": 3,
                 "system": {
-                    "id": "835379448155,
+                    "id": "835379448155",
                     "systemName": "COL 173 SECTOR ZK-O D6-24",
                     "edsmID": 58102087
                 },
@@ -15811,7 +15811,7 @@
                 "longitude": 89.5480,
                 "frontierID": 2,
                 "system": {
-                    "id": "835379448155,
+                    "id": "835379448155",
                     "systemName": "COL 173 SECTOR ZK-O D6-24",
                     "edsmID": 58102087
                 },
@@ -15829,7 +15829,7 @@
                 "longitude": 136.3990,
                 "frontierID": 1,
                 "system": {
-                    "id": "835379448155,
+                    "id": "835379448155",
                     "systemName": "COL 173 SECTOR ZK-O D6-24",
                     "edsmID": 58102087
                 },
@@ -15847,7 +15847,7 @@
                 "longitude": -127.5448,
                 "frontierID": 2,
                 "system": {
-                    "id": "85932577482,
+                    "id": "85932577482",
                     "systemName": "COL 173 SECTOR ID-Z C14-0",
                     "edsmID": 55252684
                 },
@@ -15865,7 +15865,7 @@
                 "longitude": -151.0849,
                 "frontierID": 1,
                 "system": {
-                    "id": "85932577482,
+                    "id": "85932577482",
                     "systemName": "COL 173 SECTOR ID-Z C14-0",
                     "edsmID": 55252684
                 },
@@ -15883,7 +15883,7 @@
                 "longitude": -107.6091,
                 "frontierID": 1,
                 "system": {
-                    "id": "128242061185403,
+                    "id": "128242061185403",
                     "systemName": "EORL AUWSY SY-Z D13-3732",
                     "edsmID": 22202599
                 },
@@ -15901,7 +15901,7 @@
                 "longitude": -174.8389,
                 "frontierID": 1,
                 "system": {
-                    "id": "190,
+                    "id": "190",
                     "systemName": "BLAE EORK NE-E D13-25",
                     "edsmID": 11558463
                 },
@@ -15919,7 +15919,7 @@
                 "longitude": -140.3401,
                 "frontierID": 2,
                 "system": {
-                    "id": "190,
+                    "id": "190",
                     "systemName": "BLAE EORK NE-E D13-25",
                     "edsmID": 11558463
                 },
@@ -15937,7 +15937,7 @@
                 "longitude": 133.0522,
                 "frontierID": 1,
                 "system": {
-                    "id": "866911857489,
+                    "id": "866911857489",
                     "systemName": "DROKOE FU-O B39-0",
                     "edsmID": 54338477
                 },
@@ -15955,7 +15955,7 @@
                 "longitude": 119.7074,
                 "frontierID": 2,
                 "system": {
-                    "id": "866911857489,
+                    "id": "866911857489",
                     "systemName": "DROKOE FU-O B39-0",
                     "edsmID": 54338477
                 },
@@ -15973,7 +15973,7 @@
                 "longitude": -169.6438,
                 "frontierID": 1,
                 "system": {
-                    "id": "5086179829153,
+                    "id": "5086179829153",
                     "systemName": "NGC 2516 SECTOR UT-Z B2",
                     "edsmID": 11347022
                 },
@@ -15991,7 +15991,7 @@
                 "longitude": -57.2234,
                 "frontierID": 2,
                 "system": {
-                    "id": "5086179829153,
+                    "id": "5086179829153",
                     "systemName": "NGC 2516 SECTOR UT-Z B2",
                     "edsmID": 11347022
                 },
@@ -16009,7 +16009,7 @@
                 "longitude": 123.7976,
                 "frontierID": 1,
                 "system": {
-                    "id": "634547605994,
+                    "id": "634547605994",
                     "systemName": "TRAPEZIUM SECTOR YU-X C1-2",
                     "edsmID": 1475056
                 },
@@ -16027,7 +16027,7 @@
                 "longitude": 48.1288,
                 "frontierID": 1,
                 "system": {
-                    "id": "9480736744841,
+                    "id": "9480736744841",
                     "systemName": "COL 173 SECTOR PD-B B29-4",
                     "edsmID": 66889312
                 },
@@ -16045,7 +16045,7 @@
                 "longitude": 119.1749,
                 "frontierID": 1,
                 "system": {
-                    "id": "9480736744841,
+                    "id": "9480736744841",
                     "systemName": "COL 173 SECTOR PD-B B29-4",
                     "edsmID": 66889312
                 },
@@ -16063,7 +16063,7 @@
                 "longitude": 47.1876,
                 "frontierID": 2,
                 "system": {
-                    "id": "9480736744841,
+                    "id": "9480736744841",
                     "systemName": "COL 173 SECTOR PD-B B29-4",
                     "edsmID": 66889312
                 },
@@ -16081,7 +16081,7 @@
                 "longitude": -164.7680,
                 "frontierID": 2,
                 "system": {
-                    "id": "1075947981163,
+                    "id": "1075947981163",
                     "systemName": "COL 173 SECTOR GH-L D8-31",
                     "edsmID": 67886442
                 },
@@ -16099,7 +16099,7 @@
                 "longitude": 136.1457,
                 "frontierID": 1,
                 "system": {
-                    "id": "1075947981163,
+                    "id": "1075947981163",
                     "systemName": "COL 173 SECTOR GH-L D8-31",
                     "edsmID": 67886442
                 },
@@ -16117,7 +16117,7 @@
                 "longitude": 20.7464,
                 "frontierID": 1,
                 "system": {
-                    "id": "1419511810411,
+                    "id": "1419511810411",
                     "systemName": "COL 173 SECTOR EH-L D8-41",
                     "edsmID": 24599275
                 },
@@ -16135,7 +16135,7 @@
                 "longitude": -138.3993,
                 "frontierID": 2,
                 "system": {
-                    "id": "1419511810411,
+                    "id": "1419511810411",
                     "systemName": "COL 173 SECTOR EH-L D8-41",
                     "edsmID": 24599275
                 },
@@ -16153,7 +16153,7 @@
                 "longitude": -99.8284,
                 "frontierID": 1,
                 "system": {
-                    "id": "7294607576723,
+                    "id": "7294607576723",
                     "systemName": "GRAEA HYPUE YE-Y D1-212",
                     "edsmID": 68026956
                 },
@@ -16171,7 +16171,7 @@
                 "longitude": -123.8779,
                 "frontierID": 2,
                 "system": {
-                    "id": "7294607576723,
+                    "id": "7294607576723",
                     "systemName": "GRAEA HYPUE YE-Y D1-212",
                     "edsmID": 68026956
                 },
@@ -16189,7 +16189,7 @@
                 "longitude": 21.8100,
                 "frontierID": 1,
                 "system": {
-                    "id": "104373126988,
+                    "id": "104373126988",
                     "systemName": "GRAEA HYPUE AA-Z E24",
                     "edsmID": 68065845
                 },
@@ -16207,7 +16207,7 @@
                 "longitude": -70.4834,
                 "frontierID": 1,
                 "system": {
-                    "id": "104373126988,
+                    "id": "104373126988",
                     "systemName": "GRAEA HYPUE AA-Z E24",
                     "edsmID": 68065845
                 },
@@ -16225,7 +16225,7 @@
                 "longitude": -53.7997,
                 "frontierID": 2,
                 "system": {
-                    "id": "104373126988,
+                    "id": "104373126988",
                     "systemName": "GRAEA HYPUE AA-Z E24",
                     "edsmID": 68065845
                 },
@@ -16243,7 +16243,7 @@
                 "longitude": -16.6690,
                 "frontierID": 1,
                 "system": {
-                    "id": "3343187300019,
+                    "id": "3343187300019",
                     "systemName": "GRAEA HYPUE PT-Q D5-97",
                     "edsmID": 68263223
                 },
@@ -16261,7 +16261,7 @@
                 "longitude": -161.5703,
                 "frontierID": 2,
                 "system": {
-                    "id": "3343187300019,
+                    "id": "3343187300019",
                     "systemName": "GRAEA HYPUE PT-Q D5-97",
                     "edsmID": 68263223
                 },
@@ -16279,7 +16279,7 @@
                 "longitude": 173.1957,
                 "frontierID": 1,
                 "system": {
-                    "id": "11680297461137,
+                    "id": "11680297461137",
                     "systemName": "VELA DARK REGION TD-S B4-5",
                     "edsmID": 68906163
                 },
@@ -16297,7 +16297,7 @@
                 "longitude": -150.9718,
                 "frontierID": 2,
                 "system": {
-                    "id": "11680297461137,
+                    "id": "11680297461137",
                     "systemName": "VELA DARK REGION TD-S B4-5",
                     "edsmID": 68906163
                 },
@@ -16315,7 +16315,7 @@
                 "longitude": 162.5174,
                 "frontierID": 3,
                 "system": {
-                    "id": "11680297461137,
+                    "id": "11680297461137",
                     "systemName": "VELA DARK REGION TD-S B4-5",
                     "edsmID": 68906163
                 },
@@ -16333,7 +16333,7 @@
                 "longitude": 120.3012,
                 "frontierID": 1,
                 "system": {
-                    "id": "11680297461137,
+                    "id": "11680297461137",
                     "systemName": "VELA DARK REGION TD-S B4-5",
                     "edsmID": 68906163
                 },
@@ -16351,7 +16351,7 @@
                 "longitude": 44.9471,
                 "frontierID": 1,
                 "system": {
-                    "id": "2009876632250,
+                    "id": "2009876632250",
                     "systemName": "COL 173 SECTOR VV-C C13-7",
                     "edsmID": 51659037
                 },
@@ -16369,7 +16369,7 @@
                 "longitude": -63.6531,
                 "frontierID": 2,
                 "system": {
-                    "id": "2009876632250,
+                    "id": "2009876632250",
                     "systemName": "COL 173 SECTOR VV-C C13-7",
                     "edsmID": 51659037
                 },
@@ -16387,7 +16387,7 @@
                 "longitude": 25.8088,
                 "frontierID": 1,
                 "system": {
-                    "id": "3411906776755,
+                    "id": "3411906776755",
                     "systemName": "GRAEA HYPUE PT-Q D5-99",
                     "edsmID": 68259583
                 },
@@ -16405,7 +16405,7 @@
                 "longitude": -49.3831,
                 "frontierID": 2,
                 "system": {
-                    "id": "869336551075,
+                    "id": "869336551075",
                     "systemName": "GRAEA HYPUE AG-V D3-25",
                     "edsmID": 68277746
                 },
@@ -16423,7 +16423,7 @@
                 "longitude": -11.3805,
                 "frontierID": 1,
                 "system": {
-                    "id": "869336551075,
+                    "id": "869336551075",
                     "systemName": "GRAEA HYPUE AG-V D3-25",
                     "edsmID": 68277746
                 },
@@ -16441,7 +16441,7 @@
                 "longitude": 102.1381,
                 "frontierID": 1,
                 "system": {
-                    "id": "869336551075,
+                    "id": "869336551075",
                     "systemName": "GRAEA HYPUE AG-V D3-25",
                     "edsmID": 68277746
                 },
@@ -16459,7 +16459,7 @@
                 "longitude": -35.5447,
                 "frontierID": 3,
                 "system": {
-                    "id": "688670647705,
+                    "id": "688670647705",
                     "systemName": "COL 173 SECTOR AU-Y B30-0",
                     "edsmID": 24408974
                 },
@@ -16477,7 +16477,7 @@
                 "longitude": 174.0693,
                 "frontierID": 1,
                 "system": {
-                    "id": "688670647705,
+                    "id": "688670647705",
                     "systemName": "COL 173 SECTOR AU-Y B30-0",
                     "edsmID": 24408974
                 },
@@ -16495,7 +16495,7 @@
                 "longitude": -139.9464,
                 "frontierID": 2,
                 "system": {
-                    "id": "688670647705,
+                    "id": "688670647705",
                     "systemName": "COL 173 SECTOR AU-Y B30-0",
                     "edsmID": 24408974
                 },
@@ -16513,7 +16513,7 @@
                 "longitude": -139.3551,
                 "frontierID": 1,
                 "system": {
-                    "id": "910163776186,
+                    "id": "910163776186",
                     "systemName": "COL 173 SECTOR MK-D C13-3",
                     "edsmID": 21927591
                 },
@@ -16531,7 +16531,7 @@
                 "longitude": 112.4522,
                 "frontierID": 2,
                 "system": {
-                    "id": "910163776186,
+                    "id": "910163776186",
                     "systemName": "COL 173 SECTOR MK-D C13-3",
                     "edsmID": 21927591
                 },
@@ -16549,7 +16549,7 @@
                 "longitude": -77.1914,
                 "frontierID": 3,
                 "system": {
-                    "id": "910163776186,
+                    "id": "910163776186",
                     "systemName": "COL 173 SECTOR MK-D C13-3",
                     "edsmID": 21927591
                 },
@@ -16567,7 +16567,7 @@
                 "longitude": -156.4016,
                 "frontierID": 1,
                 "system": {
-                    "id": "629170719059,
+                    "id": "629170719059",
                     "systemName": "COL 173 SECTOR OO-Q D5-18",
                     "edsmID": 53267619
                 },
@@ -16585,7 +16585,7 @@
                 "longitude": -55.3252,
                 "frontierID": 2,
                 "system": {
-                    "id": "629170719059,
+                    "id": "629170719059",
                     "systemName": "COL 173 SECTOR OO-Q D5-18",
                     "edsmID": 53267619
                 },
@@ -16603,7 +16603,7 @@
                 "longitude": 179.1323,
                 "frontierID": 3,
                 "system": {
-                    "id": "629170719059,
+                    "id": "629170719059",
                     "systemName": "COL 173 SECTOR OO-Q D5-18",
                     "edsmID": 53267619
                 },
@@ -16621,7 +16621,7 @@
                 "longitude": 13.2949,
                 "frontierID": 1,
                 "system": {
-                    "id": "629170719059,
+                    "id": "629170719059",
                     "systemName": "COL 173 SECTOR OO-Q D5-18",
                     "edsmID": 53267619
                 },
@@ -16639,7 +16639,7 @@
                 "longitude": 88.9069,
                 "frontierID": 2,
                 "system": {
-                    "id": "629170719059,
+                    "id": "629170719059",
                     "systemName": "COL 173 SECTOR OO-Q D5-18",
                     "edsmID": 53267619
                 },
@@ -16657,7 +16657,7 @@
                 "longitude": 6.3795,
                 "frontierID": 1,
                 "system": {
-                    "id": "7282787951945,
+                    "id": "7282787951945",
                     "systemName": "COL 173 SECTOR RI-R B21-3",
                     "edsmID": 50909665
                 },
@@ -16675,7 +16675,7 @@
                 "longitude": -3.8707,
                 "frontierID": 2,
                 "system": {
-                    "id": "7282787951945,
+                    "id": "7282787951945",
                     "systemName": "COL 173 SECTOR RI-R B21-3",
                     "edsmID": 50909665
                 },
@@ -16693,7 +16693,7 @@
                 "longitude": -172.5837,
                 "frontierID": 3,
                 "system": {
-                    "id": "7282787951945,
+                    "id": "7282787951945",
                     "systemName": "COL 173 SECTOR RI-R B21-3",
                     "edsmID": 50909665
                 },
@@ -16711,7 +16711,7 @@
                 "longitude": 14.3983,
                 "frontierID": 1,
                 "system": {
-                    "id": "2009944003282,
+                    "id": "2009944003282",
                     "systemName": "COL 173 SECTOR SB-Z C15-7",
                     "edsmID": 32962168
                 },
@@ -16729,7 +16729,7 @@
                 "longitude": -119.3528,
                 "frontierID": 2,
                 "system": {
-                    "id": "2009944003282,
+                    "id": "2009944003282",
                     "systemName": "COL 173 SECTOR SB-Z C15-7",
                     "edsmID": 32962168
                 },
@@ -16747,7 +16747,7 @@
                 "longitude": 9.5050,
                 "frontierID": 3,
                 "system": {
-                    "id": "2009944003282,
+                    "id": "2009944003282",
                     "systemName": "COL 173 SECTOR SB-Z C15-7",
                     "edsmID": 32962168
                 },
@@ -16765,7 +16765,7 @@
                 "longitude": -148.3974,
                 "frontierID": 1,
                 "system": {
-                    "id": "9481811469745,
+                    "id": "9481811469745",
                     "systemName": "COL 173 SECTOR JE-V B33-4",
                     "edsmID": 10225920
                 },
@@ -16783,7 +16783,7 @@
                 "longitude": -11.6896,
                 "frontierID": 2,
                 "system": {
-                    "id": "9481811469745,
+                    "id": "9481811469745",
                     "systemName": "COL 173 SECTOR JE-V B33-4",
                     "edsmID": 10225920
                 },
@@ -16801,7 +16801,7 @@
                 "longitude": -94.8628,
                 "frontierID": 3,
                 "system": {
-                    "id": "9481811469745,
+                    "id": "9481811469745",
                     "systemName": "COL 173 SECTOR JE-V B33-4",
                     "edsmID": 10225920
                 },
@@ -16819,7 +16819,7 @@
                 "longitude": 142.4189,
                 "frontierID": 1,
                 "system": {
-                    "id": "1866154871163,
+                    "id": "1866154871163",
                     "systemName": "COL 173 SECTOR IY-H D10-54",
                     "edsmID": 23831469
                 },
@@ -16837,7 +16837,7 @@
                 "longitude": -130.4144,
                 "frontierID": 2,
                 "system": {
-                    "id": "1866154871163,
+                    "id": "1866154871163",
                     "systemName": "COL 173 SECTOR IY-H D10-54",
                     "edsmID": 23831469
                 },
@@ -16855,7 +16855,7 @@
                 "longitude": -14.2210,
                 "frontierID": 1,
                 "system": {
-                    "id": "6133179650754,
+                    "id": "6133179650754",
                     "systemName": "COL 173 SECTOR PF-C C14-22",
                     "edsmID": 22987242
                 },
@@ -16873,7 +16873,7 @@
                 "longitude": -124.8500,
                 "frontierID": 2,
                 "system": {
-                    "id": "6133179650754,
+                    "id": "6133179650754",
                     "systemName": "COL 173 SECTOR PF-C C14-22",
                     "edsmID": 22987242
                 },
@@ -16891,7 +16891,7 @@
                 "longitude": 37.4016,
                 "frontierID": 3,
                 "system": {
-                    "id": "6133179650754,
+                    "id": "6133179650754",
                     "systemName": "COL 173 SECTOR PF-C C14-22",
                     "edsmID": 22987242
                 },
@@ -16909,7 +16909,7 @@
                 "longitude": 107.5815,
                 "frontierID": 1,
                 "system": {
-                    "id": "360810681026,
+                    "id": "360810681026",
                     "systemName": "COL 173 SECTOR SA-C C14-1",
                     "edsmID": 51158039
                 },
@@ -16927,7 +16927,7 @@
                 "longitude": -107.8969,
                 "frontierID": 1,
                 "system": {
-                    "id": "360810681026,
+                    "id": "360810681026",
                     "systemName": "COL 173 SECTOR SA-C C14-1",
                     "edsmID": 51158039
                 },
@@ -16945,7 +16945,7 @@
                 "longitude": -77.0579,
                 "frontierID": 2,
                 "system": {
-                    "id": "360810681026,
+                    "id": "360810681026",
                     "systemName": "COL 173 SECTOR SA-C C14-1",
                     "edsmID": 51158039
                 },
@@ -16963,7 +16963,7 @@
                 "longitude": 76.1372,
                 "frontierID": 1,
                 "system": {
-                    "id": "3824223653555,
+                    "id": "3824223653555",
                     "systemName": "GRAEA HYPUE NY-Q D5-111",
                     "edsmID": 66483950
                 },
@@ -16981,7 +16981,7 @@
                 "longitude": 128.5669,
                 "frontierID": 2,
                 "system": {
-                    "id": "3824223653555,
+                    "id": "3824223653555",
                     "systemName": "GRAEA HYPUE NY-Q D5-111",
                     "edsmID": 66483950
                 },
@@ -16999,7 +16999,7 @@
                 "longitude": -13.7725,
                 "frontierID": 1,
                 "system": {
-                    "id": "661382941827,
+                    "id": "661382941827",
                     "systemName": "PRAI HYPOO RC-C D19",
                     "edsmID": 52314661
                 },
@@ -17017,7 +17017,7 @@
                 "longitude": -22.8782,
                 "frontierID": 2,
                 "system": {
-                    "id": "661382941827,
+                    "id": "661382941827",
                     "systemName": "PRAI HYPOO RC-C D19",
                     "edsmID": 52314661
                 },
@@ -17035,7 +17035,7 @@
                 "longitude": -161.5367,
                 "frontierID": 1,
                 "system": {
-                    "id": "16055793891945,
+                    "id": "16055793891945",
                     "systemName": "GRAEA HYPUE QY-J B12-7",
                     "edsmID": 69830112
                 },
@@ -17053,7 +17053,7 @@
                 "longitude": 87.7802,
                 "frontierID": 2,
                 "system": {
-                    "id": "16055793891945,
+                    "id": "16055793891945",
                     "systemName": "GRAEA HYPUE QY-J B12-7",
                     "edsmID": 69830112
                 },
@@ -17071,7 +17071,7 @@
                 "longitude": -117.5054,
                 "frontierID": 1,
                 "system": {
-                    "id": "16055793891945,
+                    "id": "16055793891945",
                     "systemName": "GRAEA HYPUE QY-J B12-7",
                     "edsmID": 69830112
                 },
@@ -17089,7 +17089,7 @@
                 "longitude": 83.5731,
                 "frontierID": 1,
                 "system": {
-                    "id": "560115633819,
+                    "id": "560115633819",
                     "systemName": "GRAEA HYPUE DL-W D2-16",
                     "edsmID": 69829572
                 },
@@ -17107,7 +17107,7 @@
                 "longitude": 122.4173,
                 "frontierID": 2,
                 "system": {
-                    "id": "560115633819,
+                    "id": "560115633819",
                     "systemName": "GRAEA HYPUE DL-W D2-16",
                     "edsmID": 69829572
                 },
@@ -17125,7 +17125,7 @@
                 "longitude": -101.2964,
                 "frontierID": 1,
                 "system": {
-                    "id": "2861654555233,
+                    "id": "2861654555233",
                     "systemName": "GRAEA HYPUE GH-M B11-1",
                     "edsmID": 69900796
                 },
@@ -17143,7 +17143,7 @@
                 "longitude": 51.8559,
                 "frontierID": 2,
                 "system": {
-                    "id": "2861654555233,
+                    "id": "2861654555233",
                     "systemName": "GRAEA HYPUE GH-M B11-1",
                     "edsmID": 69900796
                 },
@@ -17161,7 +17161,7 @@
                 "longitude": 101.3075,
                 "frontierID": 1,
                 "system": {
-                    "id": "2071927393955,
+                    "id": "2071927393955",
                     "systemName": "GRAEA HYPUE AG-V D3-60",
                     "edsmID": 68280796
                 },
@@ -17179,7 +17179,7 @@
                 "longitude": -9.5897,
                 "frontierID": 2,
                 "system": {
-                    "id": "2071927393955,
+                    "id": "2071927393955",
                     "systemName": "GRAEA HYPUE AG-V D3-60",
                     "edsmID": 68280796
                 },
@@ -17197,7 +17197,7 @@
                 "longitude": 87.4248,
                 "frontierID": 1,
                 "system": {
-                    "id": "2243726085795,
+                    "id": "2243726085795",
                     "systemName": "GRAEA HYPUE AG-V D3-65",
                     "edsmID": 68282477
                 },
@@ -17215,7 +17215,7 @@
                 "longitude": 135.4541,
                 "frontierID": 2,
                 "system": {
-                    "id": "2243726085795,
+                    "id": "2243726085795",
                     "systemName": "GRAEA HYPUE AG-V D3-65",
                     "edsmID": 68282477
                 },
@@ -17233,7 +17233,7 @@
                 "longitude": 1.6774,
                 "frontierID": 1,
                 "system": {
-                    "id": "2243726085795,
+                    "id": "2243726085795",
                     "systemName": "GRAEA HYPUE AG-V D3-65",
                     "edsmID": 68282477
                 },
@@ -17251,7 +17251,7 @@
                 "longitude": -101.4650,
                 "frontierID": 1,
                 "system": {
-                    "id": "8737716637347,
+                    "id": "8737716637347",
                     "systemName": "GRAEA HYPUE AG-V D3-254",
                     "edsmID": 68282188
                 },
@@ -17269,7 +17269,7 @@
                 "longitude": -76.1534,
                 "frontierID": 1,
                 "system": {
-                    "id": "8737716637347,
+                    "id": "8737716637347",
                     "systemName": "GRAEA HYPUE AG-V D3-254",
                     "edsmID": 68282188
                 },
@@ -17287,7 +17287,7 @@
                 "longitude": -142.4260,
                 "frontierID": 2,
                 "system": {
-                    "id": "8737716637347,
+                    "id": "8737716637347",
                     "systemName": "GRAEA HYPUE AG-V D3-254",
                     "edsmID": 68282188
                 },
@@ -17305,7 +17305,7 @@
                 "longitude": 138.2264,
                 "frontierID": 1,
                 "system": {
-                    "id": "5095533973171,
+                    "id": "5095533973171",
                     "systemName": "GRAEA HYPUE NY-Q D5-148",
                     "edsmID": 66515319
                 },
@@ -17323,7 +17323,7 @@
                 "longitude": -45.4878,
                 "frontierID": 2,
                 "system": {
-                    "id": "5095533973171,
+                    "id": "5095533973171",
                     "systemName": "GRAEA HYPUE NY-Q D5-148",
                     "edsmID": 66515319
                 },
@@ -17341,7 +17341,7 @@
                 "longitude": -176.3978,
                 "frontierID": 1,
                 "system": {
-                    "id": "4202180759219,
+                    "id": "4202180759219",
                     "systemName": "GRAEA HYPUE PT-Q D5-122",
                     "edsmID": 68262564
                 },
@@ -17359,7 +17359,7 @@
                 "longitude": 52.1444,
                 "frontierID": 2,
                 "system": {
-                    "id": "4202180759219,
+                    "id": "4202180759219",
                     "systemName": "GRAEA HYPUE PT-Q D5-122",
                     "edsmID": 68262564
                 },
@@ -17377,7 +17377,7 @@
                 "longitude": -2.0583,
                 "frontierID": 1,
                 "system": {
-                    "id": "4202180759219,
+                    "id": "4202180759219",
                     "systemName": "GRAEA HYPUE PT-Q D5-122",
                     "edsmID": 68262564
                 },
@@ -17395,7 +17395,7 @@
                 "longitude": -41.1674,
                 "frontierID": 1,
                 "system": {
-                    "id": "29249396685417,
+                    "id": "29249396685417",
                     "systemName": "GRAEA HYPUE KI-K B12-13",
                     "edsmID": 71503730
                 },
@@ -17413,7 +17413,7 @@
                 "longitude": 165.4944,
                 "frontierID": 2,
                 "system": {
-                    "id": "29249396685417,
+                    "id": "29249396685417",
                     "systemName": "GRAEA HYPUE KI-K B12-13",
                     "edsmID": 71503730
                 },
@@ -17431,7 +17431,7 @@
                 "longitude": 102.1707,
                 "frontierID": 1,
                 "system": {
-                    "id": "2887155398881,
+                    "id": "2887155398881",
                     "systemName": "BLAA HYPAI BN-I B26-1",
                     "edsmID": 30951370
                 },
@@ -17449,7 +17449,7 @@
                 "longitude": 135.9496,
                 "frontierID": 1,
                 "system": {
-                    "id": "1460187634810,
+                    "id": "1460187634810",
                     "systemName": "BLAE HYPUE KG-C C14-5",
                     "edsmID": 1957960
                 },
@@ -17467,7 +17467,7 @@
                 "longitude": 145.2575,
                 "frontierID": 2,
                 "system": {
-                    "id": "1460187634810,
+                    "id": "1460187634810",
                     "systemName": "BLAE HYPUE KG-C C14-5",
                     "edsmID": 1957960
                 },
@@ -17485,7 +17485,7 @@
                 "longitude": 133.0830,
                 "frontierID": 3,
                 "system": {
-                    "id": "1460187634810,
+                    "id": "1460187634810",
                     "systemName": "BLAE HYPUE KG-C C14-5",
                     "edsmID": 1957960
                 },
@@ -17503,7 +17503,7 @@
                 "longitude": -73.8643,
                 "frontierID": 1,
                 "system": {
-                    "id": "216887316027,
+                    "id": "216887316027",
                     "systemName": "BLAE HYPUE DA-P D6-6",
                     "edsmID": 41899716
                 },
@@ -17521,7 +17521,7 @@
                 "longitude": 46.4268,
                 "frontierID": 2,
                 "system": {
-                    "id": "216887316027,
+                    "id": "216887316027",
                     "systemName": "BLAE HYPUE DA-P D6-6",
                     "edsmID": 41899716
                 },
@@ -17539,7 +17539,7 @@
                 "longitude": -128.0858,
                 "frontierID": 3,
                 "system": {
-                    "id": "216887316027,
+                    "id": "216887316027",
                     "systemName": "BLAE HYPUE DA-P D6-6",
                     "edsmID": 41899716
                 },
@@ -17557,7 +17557,7 @@
                 "longitude": 175.2019,
                 "frontierID": 1,
                 "system": {
-                    "id": "13879320782233,
+                    "id": "13879320782233",
                     "systemName": "VELA DARK REGION VO-Q B5-6",
                     "edsmID": 27307827
                 },
@@ -17575,7 +17575,7 @@
                 "longitude": 57.4172,
                 "frontierID": 2,
                 "system": {
-                    "id": "13879320782233,
+                    "id": "13879320782233",
                     "systemName": "VELA DARK REGION VO-Q B5-6",
                     "edsmID": 27307827
                 },
@@ -17593,7 +17593,7 @@
                 "longitude": 45.6182,
                 "frontierID": 1,
                 "system": {
-                    "id": "13879320782233,
+                    "id": "13879320782233",
                     "systemName": "VELA DARK REGION VO-Q B5-6",
                     "edsmID": 27307827
                 },
@@ -17611,7 +17611,7 @@
                 "longitude": -69.2356,
                 "frontierID": 1,
                 "system": {
-                    "id": "18277098792345,
+                    "id": "18277098792345",
                     "systemName": "VELA DARK REGION WJ-Q B5-8",
                     "edsmID": 4576041
                 },
@@ -17629,7 +17629,7 @@
                 "longitude": -153.6366,
                 "frontierID": 2,
                 "system": {
-                    "id": "18277098792345,
+                    "id": "18277098792345",
                     "systemName": "VELA DARK REGION WJ-Q B5-8",
                     "edsmID": 4576041
                 },
@@ -17647,7 +17647,7 @@
                 "longitude": -104.1185,
                 "frontierID": 1,
                 "system": {
-                    "id": "18277098792345,
+                    "id": "18277098792345",
                     "systemName": "VELA DARK REGION WJ-Q B5-8",
                     "edsmID": 4576041
                 },
@@ -17665,7 +17665,7 @@
                 "longitude": -56.4781,
                 "frontierID": 1,
                 "system": {
-                    "id": "2622153001331,
+                    "id": "2622153001331",
                     "systemName": "COL 173 SECTOR JS-J D9-76",
                     "edsmID": 71659929
                 },
@@ -17683,7 +17683,7 @@
                 "longitude": -64.2067,
                 "frontierID": 2,
                 "system": {
-                    "id": "2622153001331,
+                    "id": "2622153001331",
                     "systemName": "COL 173 SECTOR JS-J D9-76",
                     "edsmID": 71659929
                 },
@@ -17701,7 +17701,7 @@
                 "longitude": -15.1583,
                 "frontierID": 1,
                 "system": {
-                    "id": "2622153001331,
+                    "id": "2622153001331",
                     "systemName": "COL 173 SECTOR JS-J D9-76",
                     "edsmID": 71659929
                 },
@@ -17719,7 +17719,7 @@
                 "longitude": 64.1957,
                 "frontierID": 1,
                 "system": {
-                    "id": "6160669101707,
+                    "id": "6160669101707",
                     "systemName": "GRAEA HYPUE QY-Z D179",
                     "edsmID": 71840638
                 },
@@ -17737,7 +17737,7 @@
                 "longitude": 120.9913,
                 "frontierID": 1,
                 "system": {
-                    "id": "10352540421795,
+                    "id": "10352540421795",
                     "systemName": "GRAEA HYPUE ZV-U D3-301",
                     "edsmID": 72338579
                 },
@@ -17755,7 +17755,7 @@
                 "longitude": -44.7804,
                 "frontierID": 1,
                 "system": {
-                    "id": "10352540421795,
+                    "id": "10352540421795",
                     "systemName": "GRAEA HYPUE ZV-U D3-301",
                     "edsmID": 72338579
                 },
@@ -17773,7 +17773,7 @@
                 "longitude": 10.8893,
                 "frontierID": 2,
                 "system": {
-                    "id": "10352540421795,
+                    "id": "10352540421795",
                     "systemName": "GRAEA HYPUE ZV-U D3-301",
                     "edsmID": 72338579
                 },
@@ -17791,7 +17791,7 @@
                 "longitude": -99.5839,
                 "frontierID": 1,
                 "system": {
-                    "id": "8325315874475,
+                    "id": "8325315874475",
                     "systemName": "GRAEA HYPUE BH-T D4-242",
                     "edsmID": 72374710
                 },
@@ -17809,7 +17809,7 @@
                 "longitude": -15.0199,
                 "frontierID": 1,
                 "system": {
-                    "id": "8325315874475,
+                    "id": "8325315874475",
                     "systemName": "GRAEA HYPUE BH-T D4-242",
                     "edsmID": 72374710
                 },
@@ -17827,7 +17827,7 @@
                 "longitude": -135.8257,
                 "frontierID": 1,
                 "system": {
-                    "id": "2884472415729,
+                    "id": "2884472415729",
                     "systemName": "COL 173 SECTOR OP-E B41-1",
                     "edsmID": 72304984
                 },
@@ -17845,7 +17845,7 @@
                 "longitude": 154.2704,
                 "frontierID": 2,
                 "system": {
-                    "id": "2884472415729,
+                    "id": "2884472415729",
                     "systemName": "COL 173 SECTOR OP-E B41-1",
                     "edsmID": 72304984
                 },
@@ -17863,7 +17863,7 @@
                 "longitude": 36.2506,
                 "frontierID": 1,
                 "system": {
-                    "id": "7397586161315,
+                    "id": "7397586161315",
                     "systemName": "GRAEA HYPUE WA-V D3-215",
                     "edsmID": 72530769
                 },
@@ -17881,7 +17881,7 @@
                 "longitude": -143.8279,
                 "frontierID": 2,
                 "system": {
-                    "id": "8325315874475,
+                    "id": "8325315874475",
                     "systemName": "GRAEA HYPUE BH-T D4-242",
                     "edsmID": 72374710
                 },
@@ -17899,7 +17899,7 @@
                 "longitude": -2.4414,
                 "frontierID": 1,
                 "system": {
-                    "id": "5084032673305,
+                    "id": "5084032673305",
                     "systemName": "SWOILZ PA-F B3-2",
                     "edsmID": 65262529
                 },
@@ -17917,7 +17917,7 @@
                 "longitude": 145.9568,
                 "frontierID": 3,
                 "system": {
-                    "id": "5084032673305,
+                    "id": "5084032673305",
                     "systemName": "SWOILZ PA-F B3-2",
                     "edsmID": 65262529
                 },
@@ -17935,7 +17935,7 @@
                 "longitude": -19.1101,
                 "frontierID": 2,
                 "system": {
-                    "id": "5084032673305,
+                    "id": "5084032673305",
                     "systemName": "SWOILZ PA-F B3-2",
                     "edsmID": 65262529
                 },
@@ -17953,7 +17953,7 @@
                 "longitude": -54.1014,
                 "frontierID": 2,
                 "system": {
-                    "id": "3659077096194,
+                    "id": "3659077096194",
                     "systemName": "SWOILZ AE-F C13",
                     "edsmID": 73892039
                 },
@@ -17971,7 +17971,7 @@
                 "longitude": -27.8733,
                 "frontierID": 1,
                 "system": {
-                    "id": "3659077096194,
+                    "id": "3659077096194",
                     "systemName": "SWOILZ AE-F C13",
                     "edsmID": 73892039
                 },
@@ -17989,7 +17989,7 @@
                 "longitude": -116.1048,
                 "frontierID": 1,
                 "system": {
-                    "id": "687595403529,
+                    "id": "687595403529",
                     "systemName": "BLAA HYPAI PB-A B31-0",
                     "edsmID": 30872732
                 },
@@ -18007,7 +18007,7 @@
                 "longitude": 142.9382,
                 "frontierID": 2,
                 "system": {
-                    "id": "4064741822131,
+                    "id": "4064741822131",
                     "systemName": "GRAEA HYPUE NY-Q D5-118",
                     "edsmID": 66485303
                 },
@@ -18025,7 +18025,7 @@
                 "longitude": 159.0268,
                 "frontierID": 1,
                 "system": {
-                    "id": "4754830499138,
+                    "id": "4754830499138",
                     "systemName": "GRAEA HYPUE QG-Q C7-17",
                     "edsmID": 73826346
                 },
@@ -18043,7 +18043,7 @@
                 "longitude": -36.6449,
                 "frontierID": 3,
                 "system": {
-                    "id": "684375090465,
+                    "id": "684375090465",
                     "systemName": "COL 173 SECTOR UM-X B16-0",
                     "edsmID": 78214716
                 },
@@ -18061,7 +18061,7 @@
                 "longitude": 35.9730,
                 "frontierID": 1,
                 "system": {
-                    "id": "9481273943529,
+                    "id": "9481273943529",
                     "systemName": "COL 173 SECTOR DY-G B40-4",
                     "edsmID": 56302867
                 },
@@ -18079,7 +18079,7 @@
                 "longitude": -131.6533,
                 "frontierID": 2,
                 "system": {
-                    "id": "9481273943529,
+                    "id": "9481273943529",
                     "systemName": "COL 173 SECTOR DY-G B40-4",
                     "edsmID": 56302867
                 },
@@ -18097,7 +18097,7 @@
                 "longitude": 142.7258,
                 "frontierID": 3,
                 "system": {
-                    "id": "9481273943529,
+                    "id": "9481273943529",
                     "systemName": "COL 173 SECTOR DY-G B40-4",
                     "edsmID": 56302867
                 },
@@ -18115,7 +18115,7 @@
                 "longitude": -114.8900,
                 "frontierID": 1,
                 "system": {
-                    "id": "546399072737,
+                    "id": "546399072737",
                     "systemName": "NYEAJEOU VP-G B56-0",
                     "edsmID": 5459124
                 },
@@ -18133,7 +18133,7 @@
                 "longitude": 86.6656,
                 "frontierID": 2,
                 "system": {
-                    "id": "546399072737,
+                    "id": "546399072737",
                     "systemName": "NYEAJEOU VP-G B56-0",
                     "edsmID": 5459124
                 },
@@ -18151,7 +18151,7 @@
                 "longitude": -166.7135,
                 "frontierID": 1,
                 "system": {
-                    "id": "866106354521,
+                    "id": "866106354521",
                     "systemName": "DROKOE ML-M B40-0",
                     "edsmID": 54721825
                 },
@@ -18169,7 +18169,7 @@
                 "longitude": 45.0630,
                 "frontierID": 2,
                 "system": {
-                    "id": "866106354521,
+                    "id": "866106354521",
                     "systemName": "DROKOE ML-M B40-0",
                     "edsmID": 54721825
                 },
@@ -18187,7 +18187,7 @@
                 "longitude": -96.4174,
                 "frontierID": 1,
                 "system": {
-                    "id": "866106354521,
+                    "id": "866106354521",
                     "systemName": "DROKOE ML-M B40-0",
                     "edsmID": 54721825
                 },
@@ -18205,7 +18205,7 @@
                 "longitude": 93.8843,
                 "frontierID": 1,
                 "system": {
-                    "id": "866643094361,
+                    "id": "866643094361",
                     "systemName": "DROKOE SB-M B40-0",
                     "edsmID": 28977623
                 },
@@ -18223,7 +18223,7 @@
                 "longitude": -79.7276,
                 "frontierID": 2,
                 "system": {
-                    "id": "866643094361,
+                    "id": "866643094361",
                     "systemName": "DROKOE SB-M B40-0",
                     "edsmID": 28977623
                 },
@@ -18241,7 +18241,7 @@
                 "longitude": 40.3683,
                 "frontierID": 1,
                 "system": {
-                    "id": "15473399861627,
+                    "id": "15473399861627",
                     "systemName": "EORL AUWSY SY-Z D13-450",
                     "edsmID": 21583655
                 },
@@ -18259,7 +18259,7 @@
                 "longitude": 150.1474,
                 "frontierID": 2,
                 "system": {
-                    "id": "15473399861627,
+                    "id": "15473399861627",
                     "systemName": "EORL AUWSY SY-Z D13-450",
                     "edsmID": 21583655
                 },
@@ -18277,7 +18277,7 @@
                 "longitude": 98.0192,
                 "frontierID": 2,
                 "system": {
-                    "id": "6160669101707,
+                    "id": "6160669101707",
                     "systemName": "GRAEA HYPUE QY-Z D179",
                     "edsmID": 71840638
                 },
@@ -18295,7 +18295,7 @@
                 "longitude": -28.9556,
                 "frontierID": 1,
                 "system": {
-                    "id": "4754830499138,
+                    "id": "4754830499138",
                     "systemName": "GRAEA HYPUE QG-Q C7-17",
                     "edsmID": 73826346
                 },
@@ -18313,7 +18313,7 @@
                 "longitude": 11.4285,
                 "frontierID": 2,
                 "system": {
-                    "id": "4754830499138,
+                    "id": "4754830499138",
                     "systemName": "GRAEA HYPUE QG-Q C7-17",
                     "edsmID": 73826346
                 },
@@ -18331,7 +18331,7 @@
                 "longitude": 108.5511,
                 "frontierID": 1,
                 "system": {
-                    "id": "6160669101707,
+                    "id": "6160669101707",
                     "systemName": "GRAEA HYPUE QY-Z D179",
                     "edsmID": 71840638
                 },
@@ -18349,7 +18349,7 @@
                 "longitude": -132.6466,
                 "frontierID": 1,
                 "system": {
-                    "id": "2003140759187,
+                    "id": "2003140759187",
                     "systemName": "GRAEA HYPUE UE-Y D1-58",
                     "edsmID": 71854583
                 },
@@ -18367,7 +18367,7 @@
                 "longitude": 156.3242,
                 "frontierID": 1,
                 "system": {
-                    "id": "684375090465,
+                    "id": "684375090465",
                     "systemName": "COL 173 SECTOR UM-X B16-0",
                     "edsmID": 78214716
                 },
@@ -18385,7 +18385,7 @@
                 "longitude": 174.9977,
                 "frontierID": 2,
                 "system": {
-                    "id": "684375090465,
+                    "id": "684375090465",
                     "systemName": "COL 173 SECTOR UM-X B16-0",
                     "edsmID": 78214716
                 },
@@ -18403,7 +18403,7 @@
                 "longitude": 71.2402,
                 "frontierID": 2,
                 "system": {
-                    "id": "2003140759187,
+                    "id": "2003140759187",
                     "systemName": "GRAEA HYPUE UE-Y D1-58",
                     "edsmID": 71854583
                 },
@@ -18421,7 +18421,7 @@
                 "longitude": 108.6209,
                 "frontierID": 1,
                 "system": {
-                    "id": "7397586161315,
+                    "id": "7397586161315",
                     "systemName": "GRAEA HYPUE WA-V D3-215",
                     "edsmID": 72530769
                 },
@@ -18439,7 +18439,7 @@
                 "longitude": -1.8224,
                 "frontierID": 2,
                 "system": {
-                    "id": "7397586161315,
+                    "id": "7397586161315",
                     "systemName": "GRAEA HYPUE WA-V D3-215",
                     "edsmID": 72530769
                 },
@@ -18457,7 +18457,7 @@
                 "longitude": -51.3637,
                 "frontierID": 1,
                 "system": {
-                    "id": "4064741822131,
+                    "id": "4064741822131",
                     "systemName": "GRAEA HYPUE NY-Q D5-118",
                     "edsmID": 66485303
                 },
@@ -18475,7 +18475,7 @@
                 "longitude": 38.6423,
                 "frontierID": 1,
                 "system": {
-                    "id": "9428023188770,
+                    "id": "9428023188770",
                     "systemName": "GRAEA HYPUE OJ-W C3-34",
                     "edsmID": 71870004
                 },
@@ -18493,7 +18493,7 @@
                 "longitude": 146.8137,
                 "frontierID": 1,
                 "system": {
-                    "id": "9428023188770,
+                    "id": "9428023188770",
                     "systemName": "GRAEA HYPUE OJ-W C3-34",
                     "edsmID": 71870004
                 },
@@ -18511,7 +18511,7 @@
                 "longitude": 35.6404,
                 "frontierID": 2,
                 "system": {
-                    "id": "9428023188770,
+                    "id": "9428023188770",
                     "systemName": "GRAEA HYPUE OJ-W C3-34",
                     "edsmID": 71870004
                 },
@@ -18529,7 +18529,7 @@
                 "longitude": 25.8924,
                 "frontierID": 1,
                 "system": {
-                    "id": "2003140759187,
+                    "id": "2003140759187",
                     "systemName": "GRAEA HYPUE UE-Y D1-58",
                     "edsmID": 71854583
                 },
@@ -18547,7 +18547,7 @@
                 "longitude": -24.0240,
                 "frontierID": 1,
                 "system": {
-                    "id": "3171355070099,
+                    "id": "3171355070099",
                     "systemName": "GRAEA HYPUE VZ-X D1-92",
                     "edsmID": 72146588
                 },
@@ -18565,7 +18565,7 @@
                 "longitude": -152.5113,
                 "frontierID": 2,
                 "system": {
-                    "id": "3171355070099,
+                    "id": "3171355070099",
                     "systemName": "GRAEA HYPUE VZ-X D1-92",
                     "edsmID": 72146588
                 },
@@ -18583,7 +18583,7 @@
                 "longitude": -128.9278,
                 "frontierID": 1,
                 "system": {
-                    "id": "9452818610753,
+                    "id": "9452818610753",
                     "systemName": "GRAEA HYPUE YX-S B7-4",
                     "edsmID": 73593617
                 },
@@ -18601,7 +18601,7 @@
                 "longitude": -135.5623,
                 "frontierID": 2,
                 "system": {
-                    "id": "9452818610753,
+                    "id": "9452818610753",
                     "systemName": "GRAEA HYPUE YX-S B7-4",
                     "edsmID": 73593617
                 },
@@ -18619,7 +18619,7 @@
                 "longitude": 162.2237,
                 "frontierID": 1,
                 "system": {
-                    "id": "9452818610753,
+                    "id": "9452818610753",
                     "systemName": "GRAEA HYPUE YX-S B7-4",
                     "edsmID": 73593617
                 },
@@ -18637,7 +18637,7 @@
                 "longitude": 132.1540,
                 "frontierID": 2,
                 "system": {
-                    "id": "6676048416443,
+                    "id": "6676048416443",
                     "systemName": "GRAEA HYPUE LO-P D6-194",
                     "edsmID": 81969718
                 },
@@ -18655,7 +18655,7 @@
                 "longitude": -45.4324,
                 "frontierID": 1,
                 "system": {
-                    "id": "6676048416443,
+                    "id": "6676048416443",
                     "systemName": "GRAEA HYPUE LO-P D6-194",
                     "edsmID": 81969718
                 },
@@ -18673,7 +18673,7 @@
                 "longitude": -112.0908,
                 "frontierID": 1,
                 "system": {
-                    "id": "6676048416443,
+                    "id": "6676048416443",
                     "systemName": "GRAEA HYPUE LO-P D6-194",
                     "edsmID": 81969718
                 },
@@ -18691,7 +18691,7 @@
                 "longitude": -175.2525,
                 "frontierID": 2,
                 "system": {
-                    "id": "687595403529,
+                    "id": "687595403529",
                     "systemName": "BLAA HYPAI PB-A B31-0",
                     "edsmID": 30872732
                 },
@@ -18709,7 +18709,7 @@
                 "longitude": 152.6923,
                 "frontierID": 3,
                 "system": {
-                    "id": "687595403529,
+                    "id": "687595403529",
                     "systemName": "BLAA HYPAI PB-A B31-0",
                     "edsmID": 30872732
                 },
@@ -18727,7 +18727,7 @@
                 "longitude": -66.1289,
                 "frontierID": 1,
                 "system": {
-                    "id": "60030622186225,
+                    "id": "60030622186225",
                     "systemName": "GRAEA HYPUE BX-G B28-27",
                     "edsmID": 81982749
                 },
@@ -18745,7 +18745,7 @@
                 "longitude": -49.6492,
                 "frontierID": 2,
                 "system": {
-                    "id": "60030622186225,
+                    "id": "60030622186225",
                     "systemName": "GRAEA HYPUE BX-G B28-27",
                     "edsmID": 81982749
                 },
@@ -18763,7 +18763,7 @@
                 "longitude": 133.6322,
                 "frontierID": 1,
                 "system": {
-                    "id": "32243090988362,
+                    "id": "32243090988362",
                     "systemName": "GRAEA HYPUE ZR-O C8-117",
                     "edsmID": 85615689
                 },
@@ -18781,7 +18781,7 @@
                 "longitude": 168.7765,
                 "frontierID": 2,
                 "system": {
-                    "id": "32243090988362,
+                    "id": "32243090988362",
                     "systemName": "GRAEA HYPUE ZR-O C8-117",
                     "edsmID": 85615689
                 },
@@ -18799,7 +18799,7 @@
                 "longitude": 52.3970,
                 "frontierID": 1,
                 "system": {
-                    "id": "11653990202001,
+                    "id": "11653990202001",
                     "systemName": "GRAEA HYPUE UT-D B17-5",
                     "edsmID": 85627553
                 },
@@ -18817,7 +18817,7 @@
                 "longitude": -84.9641,
                 "frontierID": 1,
                 "system": {
-                    "id": "11653990202001,
+                    "id": "11653990202001",
                     "systemName": "GRAEA HYPUE UT-D B17-5",
                     "edsmID": 85627553
                 },
@@ -18835,7 +18835,7 @@
                 "longitude": -94.2089,
                 "frontierID": 2,
                 "system": {
-                    "id": "11653990202001,
+                    "id": "11653990202001",
                     "systemName": "GRAEA HYPUE UT-D B17-5",
                     "edsmID": 85627553
                 },
@@ -18853,7 +18853,7 @@
                 "longitude": 49.2790,
                 "frontierID": 1,
                 "system": {
-                    "id": "594794170731,
+                    "id": "594794170731",
                     "systemName": "COL 173 SECTOR DX-K D8-17",
                     "edsmID": 49799161
                 },
@@ -18871,7 +18871,7 @@
                 "longitude": -50.0946,
                 "frontierID": 2,
                 "system": {
-                    "id": "594794170731,
+                    "id": "594794170731",
                     "systemName": "COL 173 SECTOR DX-K D8-17",
                     "edsmID": 49799161
                 },
@@ -18889,7 +18889,7 @@
                 "longitude": -122.2400,
                 "frontierID": 1,
                 "system": {
-                    "id": "594794170731,
+                    "id": "594794170731",
                     "systemName": "COL 173 SECTOR DX-K D8-17",
                     "edsmID": 49799161
                 },
@@ -18907,7 +18907,7 @@
                 "longitude": 66.6771,
                 "frontierID": 1,
                 "system": {
-                    "id": "2884472153465,
+                    "id": "2884472153465",
                     "systemName": "COL 173 SECTOR OH-E B27-1",
                     "edsmID": 52300225
                 },
@@ -18925,7 +18925,7 @@
                 "longitude": -152.9660,
                 "frontierID": 2,
                 "system": {
-                    "id": "2884472153465,
+                    "id": "2884472153465",
                     "systemName": "COL 173 SECTOR OH-E B27-1",
                     "edsmID": 52300225
                 },
@@ -18943,7 +18943,7 @@
                 "longitude": -74.0777,
                 "frontierID": 1,
                 "system": {
-                    "id": "2285090083514,
+                    "id": "2285090083514",
                     "systemName": "COL 173 SECTOR AW-C C13-8",
                     "edsmID": 90370243
                 },
@@ -18961,7 +18961,7 @@
                 "longitude": -61.8844,
                 "frontierID": 2,
                 "system": {
-                    "id": "2285090083514,
+                    "id": "2285090083514",
                     "systemName": "COL 173 SECTOR AW-C C13-8",
                     "edsmID": 90370243
                 },
@@ -18979,7 +18979,7 @@
                 "longitude": -148.4736,
                 "frontierID": 3,
                 "system": {
-                    "id": "2285090083514,
+                    "id": "2285090083514",
                     "systemName": "COL 173 SECTOR AW-C C13-8",
                     "edsmID": 90370243
                 },
@@ -18997,7 +18997,7 @@
                 "longitude": -126.4616,
                 "frontierID": 1,
                 "system": {
-                    "id": "1385152039275,
+                    "id": "1385152039275",
                     "systemName": "NGC 2516 SECTOR EL-Y D40",
                     "edsmID": 64439935
                 },
@@ -19015,7 +19015,7 @@
                 "longitude": 72.8245,
                 "frontierID": 2,
                 "system": {
-                    "id": "1385152039275,
+                    "id": "1385152039275",
                     "systemName": "NGC 2516 SECTOR EL-Y D40",
                     "edsmID": 64439935
                 },
@@ -19033,7 +19033,7 @@
                 "longitude": 3.5693,
                 "frontierID": 3,
                 "system": {
-                    "id": "1385152039275,
+                    "id": "1385152039275",
                     "systemName": "NGC 2516 SECTOR EL-Y D40",
                     "edsmID": 64439935
                 },
@@ -19051,7 +19051,7 @@
                 "longitude": 57.8250,
                 "frontierID": 1,
                 "system": {
-                    "id": "16078075733385,
+                    "id": "16078075733385",
                     "systemName": "VELA DARK REGION IM-U B3-7",
                     "edsmID": 21057991
                 },
@@ -19069,7 +19069,7 @@
                 "longitude": 72.9146,
                 "frontierID": 2,
                 "system": {
-                    "id": "16078075733385,
+                    "id": "16078075733385",
                     "systemName": "VELA DARK REGION IM-U B3-7",
                     "edsmID": 21057991
                 },
@@ -19087,7 +19087,7 @@
                 "longitude": -142.0697,
                 "frontierID": 3,
                 "system": {
-                    "id": "16078075733385,
+                    "id": "16078075733385",
                     "systemName": "VELA DARK REGION IM-U B3-7",
                     "edsmID": 21057991
                 },
@@ -19105,7 +19105,7 @@
                 "longitude": -72.0028,
                 "frontierID": 1,
                 "system": {
-                    "id": "16078075733385,
+                    "id": "16078075733385",
                     "systemName": "VELA DARK REGION IM-U B3-7",
                     "edsmID": 21057991
                 },
@@ -19123,7 +19123,7 @@
                 "longitude": 53.8445,
                 "frontierID": 1,
                 "system": {
-                    "id": "2883398608241,
+                    "id": "2883398608241",
                     "systemName": "COL 173 SECTOR AQ-G B26-1",
                     "edsmID": 90370379
                 },
@@ -19141,7 +19141,7 @@
                 "longitude": 126.4123,
                 "frontierID": 2,
                 "system": {
-                    "id": "2883398608241,
+                    "id": "2883398608241",
                     "systemName": "COL 173 SECTOR AQ-G B26-1",
                     "edsmID": 90370379
                 },
@@ -19159,7 +19159,7 @@
                 "longitude": 138.7322,
                 "frontierID": 1,
                 "system": {
-                    "id": "684912092425,
+                    "id": "684912092425",
                     "systemName": "COL 173 SECTOR GE-D B14-0",
                     "edsmID": 52040413
                 },
@@ -19177,7 +19177,7 @@
                 "longitude": -137.2543,
                 "frontierID": 2,
                 "system": {
-                    "id": "684912092425,
+                    "id": "684912092425",
                     "systemName": "COL 173 SECTOR GE-D B14-0",
                     "edsmID": 52040413
                 },
@@ -19195,7 +19195,7 @@
                 "longitude": 23.9676,
                 "frontierID": 3,
                 "system": {
-                    "id": "684912092425,
+                    "id": "684912092425",
                     "systemName": "COL 173 SECTOR GE-D B14-0",
                     "edsmID": 52040413
                 },
@@ -19213,7 +19213,7 @@
                 "longitude": 117.1625,
                 "frontierID": 1,
                 "system": {
-                    "id": "684912092425,
+                    "id": "684912092425",
                     "systemName": "COL 173 SECTOR GE-D B14-0",
                     "edsmID": 52040413
                 },
@@ -19231,7 +19231,7 @@
                 "longitude": -63.8444,
                 "frontierID": 2,
                 "system": {
-                    "id": "684912092425,
+                    "id": "684912092425",
                     "systemName": "COL 173 SECTOR GE-D B14-0",
                     "edsmID": 52040413
                 },
@@ -19249,7 +19249,7 @@
                 "longitude": -46.3096,
                 "frontierID": 1,
                 "system": {
-                    "id": "1419444685147,
+                    "id": "1419444685147",
                     "systemName": "COL 173 SECTOR UP-O D6-41",
                     "edsmID": 22683380
                 },
@@ -19267,7 +19267,7 @@
                 "longitude": 44.2324,
                 "frontierID": 2,
                 "system": {
-                    "id": "1419444685147,
+                    "id": "1419444685147",
                     "systemName": "COL 173 SECTOR UP-O D6-41",
                     "edsmID": 22683380
                 },
@@ -19285,7 +19285,7 @@
                 "longitude": -111.8923,
                 "frontierID": 1,
                 "system": {
-                    "id": "1419444685147,
+                    "id": "1419444685147",
                     "systemName": "COL 173 SECTOR UP-O D6-41",
                     "edsmID": 22683380
                 },
@@ -19303,7 +19303,7 @@
                 "longitude": 145.8016,
                 "frontierID": 1,
                 "system": {
-                    "id": "2884203783537,
+                    "id": "2884203783537",
                     "systemName": "COL 173 SECTOR HG-G B26-1",
                     "edsmID": 9970726
                 },
@@ -19321,7 +19321,7 @@
                 "longitude": 40.7128,
                 "frontierID": 2,
                 "system": {
-                    "id": "2884203783537,
+                    "id": "2884203783537",
                     "systemName": "COL 173 SECTOR HG-G B26-1",
                     "edsmID": 9970726
                 },
@@ -19339,7 +19339,7 @@
                 "longitude": -38.3461,
                 "frontierID": 1,
                 "system": {
-                    "id": "7288961312161,
+                    "id": "7288961312161",
                     "systemName": "COL 173 SECTOR AC-W B31-3",
                     "edsmID": 90375635
                 },
@@ -19357,7 +19357,7 @@
                 "longitude": -148.3605,
                 "frontierID": 2,
                 "system": {
-                    "id": "7288961312161,
+                    "id": "7288961312161",
                     "systemName": "COL 173 SECTOR AC-W B31-3",
                     "edsmID": 90375635
                 },
@@ -19375,7 +19375,7 @@
                 "longitude": 133.5871,
                 "frontierID": 1,
                 "system": {
-                    "id": "1660080294259,
+                    "id": "1660080294259",
                     "systemName": "COL 173 SECTOR NI-J D9-48",
                     "edsmID": 90375868
                 },
@@ -19393,7 +19393,7 @@
                 "longitude": 54.1744,
                 "frontierID": 2,
                 "system": {
-                    "id": "1660080294259,
+                    "id": "1660080294259",
                     "systemName": "COL 173 SECTOR NI-J D9-48",
                     "edsmID": 90375868
                 },
@@ -19411,7 +19411,7 @@
                 "longitude": -46.5711,
                 "frontierID": 1,
                 "system": {
-                    "id": "4209034466018,
+                    "id": "4209034466018",
                     "systemName": "COL 173 SECTOR VC-W C17-15",
                     "edsmID": 90376257
                 },
@@ -19429,7 +19429,7 @@
                 "longitude": 37.3383,
                 "frontierID": 2,
                 "system": {
-                    "id": "4209034466018,
+                    "id": "4209034466018",
                     "systemName": "COL 173 SECTOR VC-W C17-15",
                     "edsmID": 90376257
                 },
@@ -19447,7 +19447,7 @@
                 "longitude": -42.6376,
                 "frontierID": 3,
                 "system": {
-                    "id": "4209034466018,
+                    "id": "4209034466018",
                     "systemName": "COL 173 SECTOR VC-W C17-15",
                     "edsmID": 90376257
                 },
@@ -19465,7 +19465,7 @@
                 "longitude": -97.3760,
                 "frontierID": 1,
                 "system": {
-                    "id": "2886084011425,
+                    "id": "2886084011425",
                     "systemName": "COL 173 SECTOR CC-Z B31-1",
                     "edsmID": 22425534
                 },
@@ -19483,7 +19483,7 @@
                 "longitude": 59.7547,
                 "frontierID": 2,
                 "system": {
-                    "id": "2886084011425,
+                    "id": "2886084011425",
                     "systemName": "COL 173 SECTOR CC-Z B31-1",
                     "edsmID": 22425534
                 },
@@ -19501,7 +19501,7 @@
                 "longitude": -106.3269,
                 "frontierID": 3,
                 "system": {
-                    "id": "2886084011425,
+                    "id": "2886084011425",
                     "systemName": "COL 173 SECTOR CC-Z B31-1",
                     "edsmID": 22425534
                 },
@@ -19519,7 +19519,7 @@
                 "longitude": 135.2118,
                 "frontierID": 1,
                 "system": {
-                    "id": "13880394917265,
+                    "id": "13880394917265",
                     "systemName": "COL 173 SECTOR TK-C B30-6",
                     "edsmID": 19073102
                 },
@@ -19537,7 +19537,7 @@
                 "longitude": -4.0969,
                 "frontierID": 2,
                 "system": {
-                    "id": "13880394917265,
+                    "id": "13880394917265",
                     "systemName": "COL 173 SECTOR TK-C B30-6",
                     "edsmID": 19073102
                 },
@@ -19555,7 +19555,7 @@
                 "longitude": -126.3214,
                 "frontierID": 3,
                 "system": {
-                    "id": "13880394917265,
+                    "id": "13880394917265",
                     "systemName": "COL 173 SECTOR TK-C B30-6",
                     "edsmID": 19073102
                 },
@@ -19573,7 +19573,7 @@
                 "longitude": 38.9017,
                 "frontierID": 1,
                 "system": {
-                    "id": "7282788476313,
+                    "id": "7282788476313",
                     "systemName": "COL 173 SECTOR PF-B B31-3",
                     "edsmID": 90377203
                 },
@@ -19591,7 +19591,7 @@
                 "longitude": -69.3824,
                 "frontierID": 2,
                 "system": {
-                    "id": "7282788476313,
+                    "id": "7282788476313",
                     "systemName": "COL 173 SECTOR PF-B B31-3",
                     "edsmID": 90377203
                 },
@@ -19609,7 +19609,7 @@
                 "longitude": -158.6119,
                 "frontierID": 3,
                 "system": {
-                    "id": "7282788476313,
+                    "id": "7282788476313",
                     "systemName": "COL 173 SECTOR PF-B B31-3",
                     "edsmID": 90377203
                 },
@@ -19627,7 +19627,7 @@
                 "longitude": -67.7380,
                 "frontierID": 1,
                 "system": {
-                    "id": "1185376902250,
+                    "id": "1185376902250",
                     "systemName": "BLAE HYPUE ZD-G C12-4",
                     "edsmID": 878504
                 },
@@ -19645,7 +19645,7 @@
                 "longitude": -85.6485,
                 "frontierID": 2,
                 "system": {
-                    "id": "1185376902250,
+                    "id": "1185376902250",
                     "systemName": "BLAE HYPUE ZD-G C12-4",
                     "edsmID": 878504
                 },
@@ -19663,7 +19663,7 @@
                 "longitude": 23.2500,
                 "frontierID": 3,
                 "system": {
-                    "id": "1185376902250,
+                    "id": "1185376902250",
                     "systemName": "BLAE HYPUE ZD-G C12-4",
                     "edsmID": 878504
                 },
@@ -19681,7 +19681,7 @@
                 "longitude": 177.4322,
                 "frontierID": 1,
                 "system": {
-                    "id": "15059908497059,
+                    "id": "15059908497059",
                     "systemName": "GRAEA HYPUE AG-V D3-438",
                     "edsmID": 68286739
                 },
@@ -19699,7 +19699,7 @@
                 "longitude": 177.4493,
                 "frontierID": 2,
                 "system": {
-                    "id": "15059908497059,
+                    "id": "15059908497059",
                     "systemName": "GRAEA HYPUE AG-V D3-438",
                     "edsmID": 68286739
                 },
@@ -19717,7 +19717,7 @@
                 "longitude": -60.0320,
                 "frontierID": 1,
                 "system": {
-                    "id": "15059908497059,
+                    "id": "15059908497059",
                     "systemName": "GRAEA HYPUE AG-V D3-438",
                     "edsmID": 68286739
                 },
@@ -19735,7 +19735,7 @@
                 "longitude": 46.6696,
                 "frontierID": 1,
                 "system": {
-                    "id": "1382920653955,
+                    "id": "1382920653955",
                     "systemName": "PRAI HYPOO SX-B D40",
                     "edsmID": 24717368
                 },
@@ -19753,7 +19753,7 @@
                 "longitude": 48.0716,
                 "frontierID": 2,
                 "system": {
-                    "id": "1382920653955,
+                    "id": "1382920653955",
                     "systemName": "PRAI HYPOO SX-B D40",
                     "edsmID": 24717368
                 },
@@ -19771,7 +19771,7 @@
                 "longitude": -61.3041,
                 "frontierID": 3,
                 "system": {
-                    "id": "1382920653955,
+                    "id": "1382920653955",
                     "systemName": "PRAI HYPOO SX-B D40",
                     "edsmID": 24717368
                 },
@@ -19789,7 +19789,7 @@
                 "longitude": -71.0092,
                 "frontierID": 1,
                 "system": {
-                    "id": "4944714084905,
+                    "id": "4944714084905",
                     "systemName": "PRAI HYPOO IU-Z B4-2",
                     "edsmID": 54673054
                 },
@@ -19807,7 +19807,7 @@
                 "longitude": 119.8630,
                 "frontierID": 2,
                 "system": {
-                    "id": "4944714084905,
+                    "id": "4944714084905",
                     "systemName": "PRAI HYPOO IU-Z B4-2",
                     "edsmID": 54673054
                 },
@@ -19825,7 +19825,7 @@
                 "longitude": -87.1851,
                 "frontierID": 3,
                 "system": {
-                    "id": "4944714084905,
+                    "id": "4944714084905",
                     "systemName": "PRAI HYPOO IU-Z B4-2",
                     "edsmID": 54673054
                 },
@@ -19843,7 +19843,7 @@
                 "longitude": -30.7198,
                 "frontierID": 1,
                 "system": {
-                    "id": "60031427558129,
+                    "id": "60031427558129",
                     "systemName": "GRAEA HYPUE CC-H B28-27",
                     "edsmID": 91950199
                 },
@@ -19861,7 +19861,7 @@
                 "longitude": 105.6536,
                 "frontierID": 2,
                 "system": {
-                    "id": "60031427558129,
+                    "id": "60031427558129",
                     "systemName": "GRAEA HYPUE CC-H B28-27",
                     "edsmID": 91950199
                 },
@@ -19879,7 +19879,7 @@
                 "longitude": -101.6007,
                 "frontierID": 1,
                 "system": {
-                    "id": "60031427558129,
+                    "id": "60031427558129",
                     "systemName": "GRAEA HYPUE CC-H B28-27",
                     "edsmID": 91950199
                 },
@@ -19897,7 +19897,7 @@
                 "longitude": -120.4733,
                 "frontierID": 1,
                 "system": {
-                    "id": "12176802323818,
+                    "id": "12176802323818",
                     "systemName": "GRAEA HYPUE UW-G C12-44",
                     "edsmID": 90371499
                 },
@@ -19915,7 +19915,7 @@
                 "longitude": 46.1478,
                 "frontierID": 2,
                 "system": {
-                    "id": "12176802323818,
+                    "id": "12176802323818",
                     "systemName": "GRAEA HYPUE UW-G C12-44",
                     "edsmID": 90371499
                 },
@@ -19933,7 +19933,7 @@
                 "longitude": -74.9815,
                 "frontierID": 1,
                 "system": {
-                    "id": "12176802323818,
+                    "id": "12176802323818",
                     "systemName": "GRAEA HYPUE UW-G C12-44",
                     "edsmID": 90371499
                 },
@@ -19951,7 +19951,7 @@
                 "longitude": -176.9575,
                 "frontierID": 1,
                 "system": {
-                    "id": "11653184174825,
+                    "id": "11653184174825",
                     "systemName": "GRAEA HYPUE FH-I B27-5",
                     "edsmID": 90386899
                 },
@@ -19969,7 +19969,7 @@
                 "longitude": 46.2937,
                 "frontierID": 1,
                 "system": {
-                    "id": "11653184174825,
+                    "id": "11653184174825",
                     "systemName": "GRAEA HYPUE FH-I B27-5",
                     "edsmID": 90386899
                 },
@@ -19987,7 +19987,7 @@
                 "longitude": 23.5611,
                 "frontierID": 2,
                 "system": {
-                    "id": "11653184174825,
+                    "id": "11653184174825",
                     "systemName": "GRAEA HYPUE FH-I B27-5",
                     "edsmID": 90386899
                 },
@@ -20005,7 +20005,7 @@
                 "longitude": -31.2805,
                 "frontierID": 1,
                 "system": {
-                    "id": "9456844880561,
+                    "id": "9456844880561",
                     "systemName": "GRAEA HYPUE ZM-T B20-4",
                     "edsmID": 55676109
                 },
@@ -20023,7 +20023,7 @@
                 "longitude": -1.5429,
                 "frontierID": 2,
                 "system": {
-                    "id": "9456844880561,
+                    "id": "9456844880561",
                     "systemName": "GRAEA HYPUE ZM-T B20-4",
                     "edsmID": 55676109
                 },
@@ -20041,7 +20041,7 @@
                 "longitude": -71.9883,
                 "frontierID": 1,
                 "system": {
-                    "id": "9456844880561,
+                    "id": "9456844880561",
                     "systemName": "GRAEA HYPUE ZM-T B20-4",
                     "edsmID": 55676109
                 },
@@ -20059,7 +20059,7 @@
                 "longitude": 74.1561,
                 "frontierID": 2,
                 "system": {
-                    "id": "9456844880561,
+                    "id": "9456844880561",
                     "systemName": "GRAEA HYPUE ZM-T B20-4",
                     "edsmID": 55676109
                 },
@@ -20077,7 +20077,7 @@
                 "longitude": -14.6328,
                 "frontierID": 1,
                 "system": {
-                    "id": "9456844880561,
+                    "id": "9456844880561",
                     "systemName": "GRAEA HYPUE ZM-T B20-4",
                     "edsmID": 55676109
                 },
@@ -20095,7 +20095,7 @@
                 "longitude": 125.4035,
                 "frontierID": 2,
                 "system": {
-                    "id": "9456844880561,
+                    "id": "9456844880561",
                     "systemName": "GRAEA HYPUE ZM-T B20-4",
                     "edsmID": 55676109
                 },
@@ -20113,7 +20113,7 @@
                 "longitude": 5.4751,
                 "frontierID": 1,
                 "system": {
-                    "id": "4996252972529,
+                    "id": "4996252972529",
                     "systemName": "SKAUDAI YE-B B58-2",
                     "edsmID": 90374019
                 },
@@ -20131,7 +20131,7 @@
                 "longitude": 147.7450,
                 "frontierID": 1,
                 "system": {
-                    "id": "4996252972529,
+                    "id": "4996252972529",
                     "systemName": "SKAUDAI YE-B B58-2",
                     "edsmID": 90374019
                 },
@@ -20149,7 +20149,7 @@
                 "longitude": 15.6853,
                 "frontierID": 2,
                 "system": {
-                    "id": "4996252972529,
+                    "id": "4996252972529",
                     "systemName": "SKAUDAI YE-B B58-2",
                     "edsmID": 90374019
                 },
@@ -20167,7 +20167,7 @@
                 "longitude": -30.8514,
                 "frontierID": 3,
                 "system": {
-                    "id": "4996252972529,
+                    "id": "4996252972529",
                     "systemName": "SKAUDAI YE-B B58-2",
                     "edsmID": 90374019
                 },

--- a/Source/data/getRuinList.json
+++ b/Source/data/getRuinList.json
@@ -6,9 +6,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 5,
+                "obeliskNumber": 1,
                 "broken": false
             },
             {
@@ -16,9 +16,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 11,
+                "obeliskNumber": 2,
                 "broken": false
             },
             {
@@ -26,9 +26,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 10,
+                "obeliskNumber": 3,
                 "broken": false
             },
             {
@@ -36,57 +36,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 8,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 4,
                 "broken": false
@@ -96,9 +46,1709 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "A"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
                 },
                 "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 8,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 13,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 5,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 9,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 14,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 5,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 9,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 14,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 4,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 6,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 7,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 8,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 9,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 8,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 1,
                 "broken": false
             },
             {
@@ -118,7 +1768,7 @@
                 "grObeliskGroup": {
                     "groupName": "M"
                 },
-                "obeliskNumber": 1,
+                "obeliskNumber": 3,
                 "broken": false
             },
             {
@@ -126,9 +1776,49 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "M"
                 },
-                "obeliskNumber": 10,
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 8,
                 "broken": true
             },
             {
@@ -136,7 +1826,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "M"
                 },
                 "obeliskNumber": 9,
                 "broken": false
@@ -146,9 +1836,19 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "M"
                 },
-                "obeliskNumber": 8,
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 11,
                 "broken": false
             },
             {
@@ -186,39 +1886,29 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "M"
                 },
-                "obeliskNumber": 4,
-                "broken": false
+                "obeliskNumber": 15,
+                "broken": true
             },
             {
                 "grType": {
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "M"
                 },
-                "obeliskNumber": 3,
-                "broken": false
+                "obeliskNumber": 16,
+                "broken": true
             },
             {
                 "grType": {
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "M"
                 },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 1,
+                "obeliskNumber": 17,
                 "broken": false
             },
             {
@@ -228,7 +1918,47 @@
                 "grObeliskGroup": {
                     "groupName": "M"
                 },
-                "obeliskNumber": 24,
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 22,
                 "broken": false
             },
             {
@@ -248,7 +1978,7 @@
                 "grObeliskGroup": {
                     "groupName": "M"
                 },
-                "obeliskNumber": 22,
+                "obeliskNumber": 24,
                 "broken": false
             },
             {
@@ -256,9 +1986,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "N"
                 },
-                "obeliskNumber": 21,
+                "obeliskNumber": 1,
                 "broken": false
             },
             {
@@ -266,9 +1996,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "N"
                 },
-                "obeliskNumber": 20,
+                "obeliskNumber": 2,
                 "broken": false
             },
             {
@@ -276,9 +2006,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "N"
                 },
-                "obeliskNumber": 19,
+                "obeliskNumber": 3,
                 "broken": false
             },
             {
@@ -286,9 +2016,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
+                    "groupName": "N"
                 },
-                "obeliskNumber": 18,
+                "obeliskNumber": 4,
                 "broken": false
             },
             {
@@ -296,57 +2026,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 16,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 15,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "N"
                 },
                 "obeliskNumber": 5,
                 "broken": false
@@ -356,7 +2036,37 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "N"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
                 },
                 "obeliskNumber": 9,
                 "broken": false
@@ -366,69 +2076,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "N"
                 },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 2,
+                "obeliskNumber": 10,
                 "broken": true
             },
             {
@@ -436,7 +2086,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "O"
                 },
                 "obeliskNumber": 1,
                 "broken": false
@@ -446,19 +2096,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 8,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 7,
+                "obeliskNumber": 2,
                 "broken": false
             },
             {
@@ -466,9 +2106,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 6,
+                "obeliskNumber": 3,
                 "broken": false
             },
             {
@@ -476,17 +2116,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "O"
                 },
                 "obeliskNumber": 4,
                 "broken": false
@@ -496,7 +2126,57 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "O"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
                 },
                 "obeliskNumber": 10,
                 "broken": false
@@ -506,7 +2186,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "O"
                 },
                 "obeliskNumber": 11,
                 "broken": false
@@ -516,7 +2196,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "O"
                 },
                 "obeliskNumber": 12,
                 "broken": false
@@ -526,169 +2206,19 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 4,
-                "broken": false
+                "obeliskNumber": 13,
+                "broken": true
             },
             {
                 "grType": {
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "O"
                 },
                 "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 29,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 11,
                 "broken": true
             },
             {
@@ -696,9 +2226,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 10,
+                "obeliskNumber": 15,
                 "broken": false
             },
             {
@@ -706,9 +2236,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 9,
+                "obeliskNumber": 16,
                 "broken": false
             },
             {
@@ -716,9 +2246,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 8,
+                "obeliskNumber": 17,
                 "broken": false
             },
             {
@@ -726,9 +2256,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 7,
+                "obeliskNumber": 18,
                 "broken": false
             },
             {
@@ -736,9 +2266,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 6,
+                "obeliskNumber": 19,
                 "broken": false
             },
             {
@@ -746,9 +2276,9 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "O"
                 },
-                "obeliskNumber": 5,
+                "obeliskNumber": 20,
                 "broken": false
             },
             {
@@ -756,37 +2286,7 @@
                     "type": "Alpha"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "P"
                 },
                 "obeliskNumber": 1,
                 "broken": false
@@ -798,7 +2298,97 @@
                 "grObeliskGroup": {
                     "groupName": "P"
                 },
-                "obeliskNumber": 13,
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 11,
                 "broken": false
             },
             {
@@ -818,8 +2408,118 @@
                 "grObeliskGroup": {
                     "groupName": "P"
                 },
-                "obeliskNumber": 11,
+                "obeliskNumber": 13,
                 "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 11,
+                "broken": true
             },
             {
                 "grType": {
@@ -849,6 +2549,136 @@
                     "groupName": "Q"
                 },
                 "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 20,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 26,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Alpha"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 27,
                 "broken": false
             },
             {
@@ -868,562 +2698,172 @@
                 "grObeliskGroup": {
                     "groupName": "Q"
                 },
-                "obeliskNumber": 27,
+                "obeliskNumber": 29,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 26,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 20,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 1,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 10,
-                "broken": true
+                "obeliskNumber": 2,
+                "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "A"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
                 },
                 "obeliskNumber": 9,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "N"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 13,
+                "obeliskNumber": 10,
                 "broken": true
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 1,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 14,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 5,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 2,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 5,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
@@ -1433,87 +2873,97 @@
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "B"
+                    "groupName": "C"
                 },
-                "obeliskNumber": 21,
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 3,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 4,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 5,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "B"
+                    "groupName": "C"
                 },
-                "obeliskNumber": 20,
-                "broken": false
+                "obeliskNumber": 6,
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "B"
+                    "groupName": "C"
                 },
-                "obeliskNumber": 19,
-                "broken": false
+                "obeliskNumber": 7,
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "B"
+                    "groupName": "C"
                 },
-                "obeliskNumber": 18,
-                "broken": false
+                "obeliskNumber": 8,
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
                 },
                 "obeliskNumber": 9,
-                "broken": true
+                "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
                 },
                 "obeliskNumber": 10,
-                "broken": true
+                "broken": false
             },
             {
                 "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
@@ -1523,1160 +2973,10 @@
             },
             {
                 "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 9,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 5,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
+                    "type": "Beta"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
-                },
-                "obeliskNumber": 14,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 13,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 8,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 7,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 6,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 4,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 14,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Alpha"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
                 },
                 "obeliskNumber": 12,
                 "broken": false
@@ -2686,7 +2986,107 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
+                    "groupName": "C"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
                 },
                 "obeliskNumber": 23,
                 "broken": false
@@ -2696,7 +3096,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 24,
                 "broken": false
@@ -2706,7 +3106,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 25,
                 "broken": false
@@ -2716,27 +3116,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 26,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 27,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 1,
                 "broken": false
@@ -2746,17 +3126,17 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 2,
-                "broken": true
+                "broken": false
             },
             {
                 "grType": {
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 3,
                 "broken": false
@@ -2766,7 +3146,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 4,
                 "broken": false
@@ -2776,117 +3156,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 20,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 5,
                 "broken": false
@@ -2896,7 +3166,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 6,
                 "broken": false
@@ -2906,9 +3176,9 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "D"
                 },
-                "obeliskNumber": 10,
+                "obeliskNumber": 7,
                 "broken": false
             },
             {
@@ -2916,9 +3186,9 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "D"
                 },
-                "obeliskNumber": 11,
+                "obeliskNumber": 8,
                 "broken": false
             },
             {
@@ -2926,67 +3196,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 9,
                 "broken": false
@@ -2996,9 +3206,9 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "D"
                 },
-                "obeliskNumber": 8,
+                "obeliskNumber": 10,
                 "broken": false
             },
             {
@@ -3006,9 +3216,9 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "D"
                 },
-                "obeliskNumber": 7,
+                "obeliskNumber": 11,
                 "broken": false
             },
             {
@@ -3016,27 +3226,17 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
+                    "groupName": "D"
                 },
-                "obeliskNumber": 7,
-                "broken": true
+                "obeliskNumber": 12,
+                "broken": false
             },
             {
                 "grType": {
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 8,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
                 },
                 "obeliskNumber": 1,
                 "broken": false
@@ -3046,7 +3246,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
                 },
                 "obeliskNumber": 2,
                 "broken": false
@@ -3056,7 +3256,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
                 },
                 "obeliskNumber": 3,
                 "broken": false
@@ -3066,7 +3266,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
                 },
                 "obeliskNumber": 4,
                 "broken": false
@@ -3076,7 +3276,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
                 },
                 "obeliskNumber": 5,
                 "broken": false
@@ -3086,7 +3286,7 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
                 },
                 "obeliskNumber": 6,
                 "broken": false
@@ -3096,7 +3296,117 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "E"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
                 },
                 "obeliskNumber": 18,
                 "broken": false
@@ -3106,10 +3416,990 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "P"
+                    "groupName": "E"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 26,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 27,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 4,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 6,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 4,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 6,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
                 },
                 "obeliskNumber": 11,
                 "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 20,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 26,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 27,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 4,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 5,
+                "broken": false
             },
             {
                 "grType": {
@@ -3126,6 +4416,116 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
                     "groupName": "N"
                 },
                 "obeliskNumber": 9,
@@ -3208,116 +4608,6 @@
                 "grObeliskGroup": {
                     "groupName": "N"
                 },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
                 "obeliskNumber": 17,
                 "broken": false
             },
@@ -3329,116 +4619,6 @@
                     "groupName": "N"
                 },
                 "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 2,
                 "broken": false
             },
             {
@@ -3526,6 +4706,116 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
                     "groupName": "P"
                 },
                 "obeliskNumber": 10,
@@ -3536,9 +4826,979 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 20,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 26,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 27,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 7,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 8,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 26,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 27,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "T"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
                     "groupName": "U"
                 },
                 "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 19,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 25,
                 "broken": false
             },
             {
@@ -3628,116 +5888,6 @@
                 "grObeliskGroup": {
                     "groupName": "U"
                 },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 19,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
                 "obeliskNumber": 34,
                 "broken": false
             },
@@ -3749,6 +5899,116 @@
                     "groupName": "U"
                 },
                 "obeliskNumber": 35,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 36,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 37,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 38,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 39,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 40,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 41,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 42,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 43,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 44,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 45,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Beta"
+                },
+                "grObeliskGroup": {
+                    "groupName": "U"
+                },
+                "obeliskNumber": 46,
                 "broken": false
             },
             {
@@ -3838,116 +6098,6 @@
                 "grObeliskGroup": {
                     "groupName": "U"
                 },
-                "obeliskNumber": 46,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 45,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 44,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 36,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 37,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 38,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 39,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 40,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 41,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 42,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 43,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
                 "obeliskNumber": 55,
                 "broken": false
             },
@@ -3958,7 +6108,7 @@
                 "grObeliskGroup": {
                     "groupName": "U"
                 },
-                "obeliskNumber": 13,
+                "obeliskNumber": 56,
                 "broken": false
             },
             {
@@ -3966,1204 +6116,634 @@
                     "type": "Beta"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "U"
                 },
-                "obeliskNumber": 19,
-                "broken": false
+                "obeliskNumber": 57,
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 1,
-                "broken": false
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 2,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 3,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 4,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 5,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 6,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 7,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 8,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "S"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 3,
+                "obeliskNumber": 9,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "S"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 2,
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 12,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "S"
+                    "groupName": "A"
                 },
-                "obeliskNumber": 1,
+                "obeliskNumber": 13,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "A"
                 },
                 "obeliskNumber": 20,
-                "broken": false
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 21,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 22,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 23,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 24,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 25,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 26,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "R"
+                    "groupName": "A"
                 },
                 "obeliskNumber": 27,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
-                "obeliskNumber": 9,
-                "broken": false
+                "obeliskNumber": 1,
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "U"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 2,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "U"
+                    "groupName": "B"
                 },
-                "obeliskNumber": 1,
+                "obeliskNumber": 3,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
                 },
                 "obeliskNumber": 11,
-                "broken": false
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 12,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 13,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 14,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 15,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 16,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 17,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "T"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 18,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "U"
+                    "groupName": "B"
                 },
-                "obeliskNumber": 12,
+                "obeliskNumber": 19,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "D"
+                    "groupName": "B"
                 },
-                "obeliskNumber": 3,
+                "obeliskNumber": 20,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "B"
+                },
+                "obeliskNumber": 21,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
+                    "groupName": "B"
                 },
-                "obeliskNumber": 3,
+                "obeliskNumber": 22,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
+                    "groupName": "B"
                 },
-                "obeliskNumber": 4,
+                "obeliskNumber": 23,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 24,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 25,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 26,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
+                    "groupName": "B"
                 },
                 "obeliskNumber": 27,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "F"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 1,
                 "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "F"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 2,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "F"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 3,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "F"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 4,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 5,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 5,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
+                    "groupName": "C"
                 },
                 "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 2,
                 "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
-                },
-                "obeliskNumber": 3,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 4,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
                 },
                 "obeliskNumber": 7,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 6,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 7,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
                 },
                 "obeliskNumber": 8,
-                "broken": true
+                "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
@@ -5173,7 +6753,7 @@
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
@@ -5183,27 +6763,27 @@
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
                 },
                 "obeliskNumber": 11,
-                "broken": false
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
                 },
                 "obeliskNumber": 12,
-                "broken": false
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
@@ -5213,7 +6793,7 @@
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "C"
@@ -5223,7 +6803,17 @@
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "C"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "D"
@@ -5233,852 +6823,822 @@
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 2,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 3,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 4,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "J"
-                },
-                "obeliskNumber": 5,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "D"
                 },
-                "obeliskNumber": 6,
+                "obeliskNumber": 5,
                 "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "D"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
                 },
                 "obeliskNumber": 7,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 8,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 9,
-                "broken": false
+                "broken": true
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "D"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
                 },
                 "obeliskNumber": 11,
-                "broken": true
+                "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "D"
                 },
                 "obeliskNumber": 12,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "D"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "D"
+                },
+                "obeliskNumber": 16,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "E"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "F"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 6,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "G"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 19,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 20,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
                 },
                 "obeliskNumber": 24,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
                 "obeliskNumber": 25,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
                 "obeliskNumber": 26,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
                 "obeliskNumber": 27,
                 "broken": false
             },
             {
                 "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 4,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 20,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
+                    "type": "Gamma"
                 },
                 "grObeliskGroup": {
                     "groupName": "H"
                 },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 4,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 6,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Beta"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 10,
+                "obeliskNumber": 28,
                 "broken": false
             },
             {
@@ -6086,9 +7646,99 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 6,
+                "obeliskNumber": 29,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 30,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 31,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 32,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 33,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 34,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 35,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 36,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 37,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "H"
+                },
+                "obeliskNumber": 38,
                 "broken": true
             },
             {
@@ -6096,49 +7746,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 11,
+                "obeliskNumber": 39,
                 "broken": true
             },
             {
@@ -6146,9 +7756,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 12,
+                "obeliskNumber": 40,
                 "broken": false
             },
             {
@@ -6156,9 +7766,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 13,
+                "obeliskNumber": 41,
                 "broken": false
             },
             {
@@ -6166,9 +7776,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 14,
+                "obeliskNumber": 42,
                 "broken": false
             },
             {
@@ -6176,9 +7786,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 5,
+                "obeliskNumber": 43,
                 "broken": false
             },
             {
@@ -6186,9 +7796,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 4,
+                "obeliskNumber": 44,
                 "broken": false
             },
             {
@@ -6196,9 +7806,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "L"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 3,
+                "obeliskNumber": 45,
                 "broken": false
             },
             {
@@ -6206,9 +7816,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 10,
+                "obeliskNumber": 46,
                 "broken": false
             },
             {
@@ -6216,9 +7826,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 11,
+                "obeliskNumber": 47,
                 "broken": false
             },
             {
@@ -6226,9 +7836,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 12,
+                "obeliskNumber": 48,
                 "broken": false
             },
             {
@@ -6236,279 +7846,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "H"
                 },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "L"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "K"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 4,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "M"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 8,
+                "obeliskNumber": 49,
                 "broken": false
             },
             {
@@ -6519,116 +7859,6 @@
                     "groupName": "H"
                 },
                 "obeliskNumber": 50,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 2,
                 "broken": false
             },
             {
@@ -6718,6 +7948,116 @@
                 "grObeliskGroup": {
                     "groupName": "I"
                 },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
                 "obeliskNumber": 13,
                 "broken": false
             },
@@ -6739,6 +8079,116 @@
                     "groupName": "I"
                 },
                 "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "I"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 2,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 6,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "J"
+                },
+                "obeliskNumber": 8,
                 "broken": false
             },
             {
@@ -6826,7 +8276,7 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "K"
                 },
                 "obeliskNumber": 8,
                 "broken": false
@@ -6836,9 +8286,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "K"
                 },
-                "obeliskNumber": 7,
+                "obeliskNumber": 9,
                 "broken": false
             },
             {
@@ -6846,19 +8296,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "K"
                 },
-                "obeliskNumber": 6,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "I"
-                },
-                "obeliskNumber": 16,
+                "obeliskNumber": 10,
                 "broken": false
             },
             {
@@ -6866,9 +8306,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "I"
+                    "groupName": "K"
                 },
-                "obeliskNumber": 17,
+                "obeliskNumber": 11,
                 "broken": false
             },
             {
@@ -6876,9 +8316,9 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "I"
+                    "groupName": "K"
                 },
-                "obeliskNumber": 18,
+                "obeliskNumber": 12,
                 "broken": false
             },
             {
@@ -6886,7 +8326,37 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "K"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "K"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
                 },
                 "obeliskNumber": 1,
                 "broken": true
@@ -6896,17 +8366,17 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "L"
                 },
                 "obeliskNumber": 2,
-                "broken": true
+                "broken": false
             },
             {
                 "grType": {
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "L"
                 },
                 "obeliskNumber": 3,
                 "broken": false
@@ -6916,7 +8386,7 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "L"
                 },
                 "obeliskNumber": 4,
                 "broken": false
@@ -6926,7 +8396,7 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "J"
+                    "groupName": "L"
                 },
                 "obeliskNumber": 5,
                 "broken": false
@@ -6936,7 +8406,797 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
-                    "groupName": "K"
+                    "groupName": "L"
+                },
+                "obeliskNumber": 6,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "L"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "M"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 4,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 9,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 10,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 11,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "N"
+                },
+                "obeliskNumber": 14,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "O"
+                },
+                "obeliskNumber": 8,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 1,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 8,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 11,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 12,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 13,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 14,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 15,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 16,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 17,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 18,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 19,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 20,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 21,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 22,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 23,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 26,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "P"
+                },
+                "obeliskNumber": 27,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
                 },
                 "obeliskNumber": 8,
                 "broken": false
@@ -6948,7 +9208,57 @@
                 "grObeliskGroup": {
                     "groupName": "Q"
                 },
+                "obeliskNumber": 9,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "Q"
+                },
+                "obeliskNumber": 10,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
                 "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 4,
                 "broken": false
             },
             {
@@ -7038,116 +9348,6 @@
                 "grObeliskGroup": {
                     "groupName": "R"
                 },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
                 "obeliskNumber": 13,
                 "broken": false
             },
@@ -7169,116 +9369,6 @@
                     "groupName": "R"
                 },
                 "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 27,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "S"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 26,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "R"
-                },
-                "obeliskNumber": 24,
                 "broken": false
             },
             {
@@ -7366,2159 +9456,119 @@
                     "type": "Gamma"
                 },
                 "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 24,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 25,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 26,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "R"
+                },
+                "obeliskNumber": 27,
+                "broken": true
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 1,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 2,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 3,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 4,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 5,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 6,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
+                    "groupName": "S"
+                },
+                "obeliskNumber": 7,
+                "broken": false
+            },
+            {
+                "grType": {
+                    "type": "Gamma"
+                },
+                "grObeliskGroup": {
                     "groupName": "S"
                 },
                 "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 9,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 8,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "N"
-                },
-                "obeliskNumber": 14,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "O"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 26,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 27,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 20,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "P"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "Q"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 6,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 27,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 26,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 20,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 12,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 9,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "C"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "D"
-                },
-                "obeliskNumber": 5,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 19,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 20,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 26,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "A"
-                },
-                "obeliskNumber": 27,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "B"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 19,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 20,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 21,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 22,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 23,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 24,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 25,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 26,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 18,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 17,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 16,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 11,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 27,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 28,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 29,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 41,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 42,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 43,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 44,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 45,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 46,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 47,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 48,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 40,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 39,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 38,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 30,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 31,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 32,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 33,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 34,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 35,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 36,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 37,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 49,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 10,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 6,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "E"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "F"
-                },
-                "obeliskNumber": 15,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 12,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 13,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 14,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 1,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 2,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 11,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 10,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 9,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 1,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 2,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 3,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 4,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 5,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 6,
-                "broken": true
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 7,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "G"
-                },
-                "obeliskNumber": 8,
-                "broken": false
-            },
-            {
-                "grType": {
-                    "type": "Gamma"
-                },
-                "grObeliskGroup": {
-                    "groupName": "H"
-                },
-                "obeliskNumber": 6,
                 "broken": false
             }
         ],

--- a/Source/data/siteids/1.json
+++ b/Source/data/siteids/1.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/10.json
+++ b/Source/data/siteids/10.json
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -189,7 +189,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/100.json
+++ b/Source/data/siteids/100.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -215,7 +215,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -237,7 +237,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -259,7 +259,7 @@
                         },
                         "obeliskNumber": 31,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/101.json
+++ b/Source/data/siteids/101.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 28,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/102.json
+++ b/Source/data/siteids/102.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 30,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/103.json
+++ b/Source/data/siteids/103.json
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -431,7 +431,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/104.json
+++ b/Source/data/siteids/104.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -321,7 +321,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/105.json
+++ b/Source/data/siteids/105.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/106.json
+++ b/Source/data/siteids/106.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -321,7 +321,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/107.json
+++ b/Source/data/siteids/107.json
@@ -27,7 +27,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -189,7 +189,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -383,7 +383,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -405,7 +405,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -427,7 +427,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/108.json
+++ b/Source/data/siteids/108.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -489,7 +489,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -511,7 +511,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -531,7 +531,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -553,7 +553,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/109.json
+++ b/Source/data/siteids/109.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/11.json
+++ b/Source/data/siteids/11.json
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -533,7 +533,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/110.json
+++ b/Source/data/siteids/110.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -489,7 +489,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -511,7 +511,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -531,7 +531,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -553,7 +553,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/111.json
+++ b/Source/data/siteids/111.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -195,7 +195,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -217,7 +217,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -327,7 +327,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -349,7 +349,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -371,7 +371,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/112.json
+++ b/Source/data/siteids/112.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/113.json
+++ b/Source/data/siteids/113.json
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -189,7 +189,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/114.json
+++ b/Source/data/siteids/114.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/115.json
+++ b/Source/data/siteids/115.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/116.json
+++ b/Source/data/siteids/116.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/117.json
+++ b/Source/data/siteids/117.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -217,7 +217,7 @@
                         },
                         "obeliskNumber": 32,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 35,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/118.json
+++ b/Source/data/siteids/118.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -89,7 +89,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/119.json
+++ b/Source/data/siteids/119.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 48,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/12.json
+++ b/Source/data/siteids/12.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -349,7 +349,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -391,7 +391,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -435,7 +435,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -457,7 +457,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -479,7 +479,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -501,7 +501,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -523,7 +523,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -543,7 +543,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -563,7 +563,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -607,7 +607,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -629,7 +629,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -651,7 +651,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -673,7 +673,7 @@
                         },
                         "obeliskNumber": 28,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/120.json
+++ b/Source/data/siteids/120.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/121.json
+++ b/Source/data/siteids/121.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/122.json
+++ b/Source/data/siteids/122.json
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -515,7 +515,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -559,7 +559,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/123.json
+++ b/Source/data/siteids/123.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 32,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -503,7 +503,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -547,7 +547,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -567,7 +567,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -589,7 +589,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -611,7 +611,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -655,7 +655,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/124.json
+++ b/Source/data/siteids/124.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/125.json
+++ b/Source/data/siteids/125.json
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -371,7 +371,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -435,7 +435,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -457,7 +457,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -479,7 +479,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -501,7 +501,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/126.json
+++ b/Source/data/siteids/126.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/127.json
+++ b/Source/data/siteids/127.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/128.json
+++ b/Source/data/siteids/128.json
@@ -27,7 +27,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -341,7 +341,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/129.json
+++ b/Source/data/siteids/129.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -211,7 +211,7 @@
                         },
                         "obeliskNumber": 45,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/13.json
+++ b/Source/data/siteids/13.json
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/130.json
+++ b/Source/data/siteids/130.json
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/131.json
+++ b/Source/data/siteids/131.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 43,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -495,7 +495,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/132.json
+++ b/Source/data/siteids/132.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/133.json
+++ b/Source/data/siteids/133.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -383,7 +383,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/134.json
+++ b/Source/data/siteids/134.json
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/135.json
+++ b/Source/data/siteids/135.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/136.json
+++ b/Source/data/siteids/136.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 30,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/137.json
+++ b/Source/data/siteids/137.json
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -324,7 +324,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -346,7 +346,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -368,7 +368,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -390,7 +390,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -412,7 +412,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -434,7 +434,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -456,7 +456,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -478,7 +478,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -500,7 +500,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/138.json
+++ b/Source/data/siteids/138.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -189,7 +189,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -211,7 +211,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/139.json
+++ b/Source/data/siteids/139.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 36,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -357,7 +357,7 @@
                         },
                         "obeliskNumber": 56,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -531,7 +531,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -553,7 +553,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/14.json
+++ b/Source/data/siteids/14.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -405,7 +405,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -471,7 +471,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -493,7 +493,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -515,7 +515,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -537,7 +537,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -625,7 +625,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -647,7 +647,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -669,7 +669,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -691,7 +691,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -735,7 +735,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -779,7 +779,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/140.json
+++ b/Source/data/siteids/140.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -195,7 +195,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/141.json
+++ b/Source/data/siteids/141.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 41,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/142.json
+++ b/Source/data/siteids/142.json
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/143.json
+++ b/Source/data/siteids/143.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/144.json
+++ b/Source/data/siteids/144.json
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/145.json
+++ b/Source/data/siteids/145.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/146.json
+++ b/Source/data/siteids/146.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -357,7 +357,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -379,7 +379,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -401,7 +401,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/147.json
+++ b/Source/data/siteids/147.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -261,7 +261,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -349,7 +349,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -391,7 +391,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -413,7 +413,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/148.json
+++ b/Source/data/siteids/148.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -371,7 +371,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -413,7 +413,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -435,7 +435,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -457,7 +457,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -479,7 +479,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -501,7 +501,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/149.json
+++ b/Source/data/siteids/149.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -215,7 +215,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -237,7 +237,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -321,7 +321,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -429,7 +429,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -495,7 +495,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -605,7 +605,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -627,7 +627,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/15.json
+++ b/Source/data/siteids/15.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -527,7 +527,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/150.json
+++ b/Source/data/siteids/150.json
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -217,7 +217,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/151.json
+++ b/Source/data/siteids/151.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -529,7 +529,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -551,7 +551,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -573,7 +573,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -595,7 +595,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/152.json
+++ b/Source/data/siteids/152.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -227,7 +227,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/153.json
+++ b/Source/data/siteids/153.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -211,7 +211,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -255,7 +255,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -383,7 +383,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/154.json
+++ b/Source/data/siteids/154.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -217,7 +217,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -305,7 +305,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -411,7 +411,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -433,7 +433,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -455,7 +455,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -477,7 +477,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/155.json
+++ b/Source/data/siteids/155.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/156.json
+++ b/Source/data/siteids/156.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/157.json
+++ b/Source/data/siteids/157.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -305,7 +305,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -338,7 +338,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -358,7 +358,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -380,7 +380,7 @@
                         },
                         "obeliskNumber": 49,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -402,7 +402,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -424,7 +424,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -446,7 +446,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -468,7 +468,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -508,7 +508,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -552,7 +552,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -574,7 +574,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -618,7 +618,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/158.json
+++ b/Source/data/siteids/158.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -405,7 +405,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -427,7 +427,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -449,7 +449,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/159.json
+++ b/Source/data/siteids/159.json
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -481,7 +481,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/16.json
+++ b/Source/data/siteids/16.json
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/160.json
+++ b/Source/data/siteids/160.json
@@ -89,7 +89,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/161.json
+++ b/Source/data/siteids/161.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -139,7 +139,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -161,7 +161,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 28,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/162.json
+++ b/Source/data/siteids/162.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -77,7 +77,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 28,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 45,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/163.json
+++ b/Source/data/siteids/163.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/164.json
+++ b/Source/data/siteids/164.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/165.json
+++ b/Source/data/siteids/165.json
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/166.json
+++ b/Source/data/siteids/166.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -215,7 +215,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -237,7 +237,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -259,7 +259,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -281,7 +281,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -303,7 +303,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -325,7 +325,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -369,7 +369,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -391,7 +391,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -411,7 +411,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -431,7 +431,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -453,7 +453,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -495,7 +495,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -605,7 +605,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/167.json
+++ b/Source/data/siteids/167.json
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/168.json
+++ b/Source/data/siteids/168.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -215,7 +215,7 @@
                         },
                         "obeliskNumber": 53,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -237,7 +237,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/169.json
+++ b/Source/data/siteids/169.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/17.json
+++ b/Source/data/siteids/17.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/170.json
+++ b/Source/data/siteids/170.json
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/171.json
+++ b/Source/data/siteids/171.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -139,7 +139,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -227,7 +227,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/172.json
+++ b/Source/data/siteids/172.json
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -481,7 +481,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -503,7 +503,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/173.json
+++ b/Source/data/siteids/173.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 26
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/174.json
+++ b/Source/data/siteids/174.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -139,7 +139,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/175.json
+++ b/Source/data/siteids/175.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/176.json
+++ b/Source/data/siteids/176.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -89,7 +89,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/177.json
+++ b/Source/data/siteids/177.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/178.json
+++ b/Source/data/siteids/178.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -481,7 +481,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -503,7 +503,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/179.json
+++ b/Source/data/siteids/179.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -139,7 +139,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -161,7 +161,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/18.json
+++ b/Source/data/siteids/18.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/180.json
+++ b/Source/data/siteids/180.json
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -312,7 +312,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -334,7 +334,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -356,7 +356,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -378,7 +378,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -400,7 +400,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -422,7 +422,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/181.json
+++ b/Source/data/siteids/181.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -195,7 +195,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -261,7 +261,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -303,7 +303,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -325,7 +325,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -369,7 +369,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -391,7 +391,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/182.json
+++ b/Source/data/siteids/182.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -151,7 +151,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -195,7 +195,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -261,7 +261,7 @@
                         },
                         "obeliskNumber": 34,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/183.json
+++ b/Source/data/siteids/183.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/184.json
+++ b/Source/data/siteids/184.json
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -411,7 +411,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -433,7 +433,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/185.json
+++ b/Source/data/siteids/185.json
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -303,7 +303,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -325,7 +325,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -433,7 +433,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/186.json
+++ b/Source/data/siteids/186.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/187.json
+++ b/Source/data/siteids/187.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 32,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 40,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 50,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -513,7 +513,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -535,7 +535,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -557,7 +557,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -579,7 +579,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/188.json
+++ b/Source/data/siteids/188.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/189.json
+++ b/Source/data/siteids/189.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 31,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 49,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -457,7 +457,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -479,7 +479,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -523,7 +523,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -545,7 +545,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -567,7 +567,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -589,7 +589,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -611,7 +611,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -633,7 +633,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/19.json
+++ b/Source/data/siteids/19.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -227,7 +227,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/190.json
+++ b/Source/data/siteids/190.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 50,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -505,7 +505,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -527,7 +527,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -549,7 +549,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -571,7 +571,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/191.json
+++ b/Source/data/siteids/191.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -195,7 +195,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -283,7 +283,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -327,7 +327,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -349,7 +349,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/192.json
+++ b/Source/data/siteids/192.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -215,7 +215,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -237,7 +237,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -433,7 +433,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -477,7 +477,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -499,7 +499,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -521,7 +521,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -565,7 +565,7 @@
                         },
                         "obeliskNumber": 34,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -587,7 +587,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -609,7 +609,7 @@
                         },
                         "obeliskNumber": 40,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -697,7 +697,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -719,7 +719,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -741,7 +741,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -763,7 +763,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -785,7 +785,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -805,7 +805,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -827,7 +827,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -871,7 +871,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/193.json
+++ b/Source/data/siteids/193.json
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/194.json
+++ b/Source/data/siteids/194.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -513,7 +513,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -535,7 +535,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -557,7 +557,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/195.json
+++ b/Source/data/siteids/195.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -429,7 +429,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -451,7 +451,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -495,7 +495,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -627,7 +627,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -647,7 +647,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -669,7 +669,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -689,7 +689,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -711,7 +711,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -733,7 +733,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -753,7 +753,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -775,7 +775,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -797,7 +797,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -819,7 +819,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -863,7 +863,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/196.json
+++ b/Source/data/siteids/196.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -423,7 +423,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -489,7 +489,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -511,7 +511,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -533,7 +533,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -555,7 +555,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/197.json
+++ b/Source/data/siteids/197.json
@@ -57,7 +57,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -511,7 +511,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/198.json
+++ b/Source/data/siteids/198.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/199.json
+++ b/Source/data/siteids/199.json
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -278,7 +278,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -300,7 +300,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -322,7 +322,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -342,7 +342,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -364,7 +364,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -406,7 +406,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -450,7 +450,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -472,7 +472,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -494,7 +494,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/2.json
+++ b/Source/data/siteids/2.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/20.json
+++ b/Source/data/siteids/20.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/200.json
+++ b/Source/data/siteids/200.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -89,7 +89,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 50,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -371,7 +371,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/201.json
+++ b/Source/data/siteids/201.json
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/202.json
+++ b/Source/data/siteids/202.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -481,7 +481,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -503,7 +503,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/203.json
+++ b/Source/data/siteids/203.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/204.json
+++ b/Source/data/siteids/204.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -327,7 +327,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -371,7 +371,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -499,7 +499,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -521,7 +521,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -543,7 +543,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -563,7 +563,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -585,7 +585,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -607,7 +607,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -629,7 +629,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -651,7 +651,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/205.json
+++ b/Source/data/siteids/205.json
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -255,7 +255,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -277,7 +277,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -321,7 +321,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/206.json
+++ b/Source/data/siteids/206.json
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/207.json
+++ b/Source/data/siteids/207.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 28,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/208.json
+++ b/Source/data/siteids/208.json
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -509,7 +509,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -531,7 +531,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/209.json
+++ b/Source/data/siteids/209.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/21.json
+++ b/Source/data/siteids/21.json
@@ -57,7 +57,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 30,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/210.json
+++ b/Source/data/siteids/210.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/211.json
+++ b/Source/data/siteids/211.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -383,7 +383,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -405,7 +405,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -427,7 +427,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -471,7 +471,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -493,7 +493,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/212.json
+++ b/Source/data/siteids/212.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -89,7 +89,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -305,7 +305,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/213.json
+++ b/Source/data/siteids/213.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -139,7 +139,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -161,7 +161,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -183,7 +183,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/214.json
+++ b/Source/data/siteids/214.json
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -324,7 +324,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -346,7 +346,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -368,7 +368,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -390,7 +390,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -412,7 +412,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -434,7 +434,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -456,7 +456,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/215.json
+++ b/Source/data/siteids/215.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/216.json
+++ b/Source/data/siteids/216.json
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/217.json
+++ b/Source/data/siteids/217.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/218.json
+++ b/Source/data/siteids/218.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -246,7 +246,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -268,7 +268,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -290,7 +290,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -312,7 +312,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -332,7 +332,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/219.json
+++ b/Source/data/siteids/219.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -227,7 +227,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/22.json
+++ b/Source/data/siteids/22.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/220.json
+++ b/Source/data/siteids/220.json
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/221.json
+++ b/Source/data/siteids/221.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 48,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/222.json
+++ b/Source/data/siteids/222.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/223.json
+++ b/Source/data/siteids/223.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/224.json
+++ b/Source/data/siteids/224.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -306,7 +306,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/225.json
+++ b/Source/data/siteids/225.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -151,7 +151,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -195,7 +195,7 @@
                         },
                         "obeliskNumber": 32,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -217,7 +217,7 @@
                         },
                         "obeliskNumber": 34,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 35,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -261,7 +261,7 @@
                         },
                         "obeliskNumber": 49,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -305,7 +305,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -327,7 +327,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -371,7 +371,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -479,7 +479,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/226.json
+++ b/Source/data/siteids/226.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -369,7 +369,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -413,7 +413,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/227.json
+++ b/Source/data/siteids/227.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -162,7 +162,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -184,7 +184,7 @@
                         },
                         "obeliskNumber": 31,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -206,7 +206,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -228,7 +228,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -250,7 +250,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -294,7 +294,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -360,7 +360,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -382,7 +382,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -426,7 +426,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -446,7 +446,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -468,7 +468,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -490,7 +490,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/228.json
+++ b/Source/data/siteids/228.json
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -211,7 +211,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -233,7 +233,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -277,7 +277,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -341,7 +341,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/229.json
+++ b/Source/data/siteids/229.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -255,7 +255,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -277,7 +277,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -321,7 +321,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/23.json
+++ b/Source/data/siteids/23.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -379,7 +379,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -401,7 +401,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/236.json
+++ b/Source/data/siteids/236.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -237,7 +237,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -259,7 +259,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -303,7 +303,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -325,7 +325,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -369,7 +369,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -411,7 +411,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -455,7 +455,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -477,7 +477,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -499,7 +499,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/237.json
+++ b/Source/data/siteids/237.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -189,7 +189,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/24.json
+++ b/Source/data/siteids/24.json
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/25.json
+++ b/Source/data/siteids/25.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/255.json
+++ b/Source/data/siteids/255.json
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -341,7 +341,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -513,7 +513,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/26.json
+++ b/Source/data/siteids/26.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/260.json
+++ b/Source/data/siteids/260.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/261.json
+++ b/Source/data/siteids/261.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -489,7 +489,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -533,7 +533,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -555,7 +555,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -577,7 +577,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/262.json
+++ b/Source/data/siteids/262.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 33,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/265.json
+++ b/Source/data/siteids/265.json
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/267.json
+++ b/Source/data/siteids/267.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -509,7 +509,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/268.json
+++ b/Source/data/siteids/268.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -357,7 +357,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -390,7 +390,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/269.json
+++ b/Source/data/siteids/269.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -255,7 +255,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -277,7 +277,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/27.json
+++ b/Source/data/siteids/27.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -255,7 +255,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 32,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -405,7 +405,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -515,7 +515,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -535,7 +535,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -557,7 +557,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -601,7 +601,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -623,7 +623,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -645,7 +645,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/270.json
+++ b/Source/data/siteids/270.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -167,7 +167,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -200,7 +200,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/271.json
+++ b/Source/data/siteids/271.json
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -256,7 +256,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -278,7 +278,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -300,7 +300,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/272.json
+++ b/Source/data/siteids/272.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/277.json
+++ b/Source/data/siteids/277.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -533,7 +533,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -555,7 +555,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -577,7 +577,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -597,7 +597,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/278.json
+++ b/Source/data/siteids/278.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -277,7 +277,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -321,7 +321,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -431,7 +431,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -453,7 +453,7 @@
                         },
                         "obeliskNumber": 40,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -475,7 +475,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -497,7 +497,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -603,7 +603,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -623,7 +623,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -645,7 +645,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -667,7 +667,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/279.json
+++ b/Source/data/siteids/279.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -83,7 +83,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/28.json
+++ b/Source/data/siteids/28.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/283.json
+++ b/Source/data/siteids/283.json
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -261,7 +261,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -400,7 +400,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -422,7 +422,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -444,7 +444,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -466,7 +466,7 @@
                         },
                         "obeliskNumber": 28,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/284.json
+++ b/Source/data/siteids/284.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -254,7 +254,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/285.json
+++ b/Source/data/siteids/285.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -357,7 +357,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -379,7 +379,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -401,7 +401,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -445,7 +445,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/286.json
+++ b/Source/data/siteids/286.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -250,7 +250,7 @@
                         },
                         "obeliskNumber": 56,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -314,7 +314,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -334,7 +334,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -378,7 +378,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -398,7 +398,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -420,7 +420,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -442,7 +442,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -464,7 +464,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/287.json
+++ b/Source/data/siteids/287.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -183,7 +183,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -355,7 +355,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/288.json
+++ b/Source/data/siteids/288.json
@@ -27,7 +27,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -455,7 +455,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -519,7 +519,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -605,7 +605,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/289.json
+++ b/Source/data/siteids/289.json
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/29.json
+++ b/Source/data/siteids/29.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/290.json
+++ b/Source/data/siteids/290.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 46,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -383,7 +383,7 @@
                         },
                         "obeliskNumber": 49,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -405,7 +405,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -449,7 +449,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -513,7 +513,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -555,7 +555,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -577,7 +577,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -621,7 +621,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/291.json
+++ b/Source/data/siteids/291.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -101,7 +101,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -123,7 +123,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/292.json
+++ b/Source/data/siteids/292.json
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -202,7 +202,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -224,7 +224,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -246,7 +246,7 @@
                         },
                         "obeliskNumber": 34,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -268,7 +268,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -290,7 +290,7 @@
                         },
                         "obeliskNumber": 40,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -312,7 +312,7 @@
                         },
                         "obeliskNumber": 53,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -334,7 +334,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -354,7 +354,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -420,7 +420,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -442,7 +442,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -486,7 +486,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -508,7 +508,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -530,7 +530,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -552,7 +552,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -574,7 +574,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -662,7 +662,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/293.json
+++ b/Source/data/siteids/293.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 43,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 46,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -505,7 +505,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/294.json
+++ b/Source/data/siteids/294.json
@@ -57,7 +57,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -403,7 +403,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -425,7 +425,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -445,7 +445,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -489,7 +489,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/299.json
+++ b/Source/data/siteids/299.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -206,7 +206,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -272,7 +272,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/3.json
+++ b/Source/data/siteids/3.json
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/30.json
+++ b/Source/data/siteids/30.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -451,7 +451,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -495,7 +495,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/300.json
+++ b/Source/data/siteids/300.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/301.json
+++ b/Source/data/siteids/301.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -439,7 +439,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/302.json
+++ b/Source/data/siteids/302.json
@@ -27,7 +27,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -236,7 +236,7 @@
                         },
                         "obeliskNumber": 31,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -258,7 +258,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -280,7 +280,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -324,7 +324,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -344,7 +344,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -388,7 +388,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -410,7 +410,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -454,7 +454,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -498,7 +498,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -520,7 +520,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -542,7 +542,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/31.json
+++ b/Source/data/siteids/31.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -161,7 +161,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -183,7 +183,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 33,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 48,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -357,7 +357,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -379,7 +379,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/32.json
+++ b/Source/data/siteids/32.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 32,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -505,7 +505,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -547,7 +547,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/33.json
+++ b/Source/data/siteids/33.json
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/34.json
+++ b/Source/data/siteids/34.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 31,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 43,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/35.json
+++ b/Source/data/siteids/35.json
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -511,7 +511,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/36.json
+++ b/Source/data/siteids/36.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -191,7 +191,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/37.json
+++ b/Source/data/siteids/37.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/38.json
+++ b/Source/data/siteids/38.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -287,7 +287,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -331,7 +331,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -375,7 +375,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -503,7 +503,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -525,7 +525,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -547,7 +547,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/39.json
+++ b/Source/data/siteids/39.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/4.json
+++ b/Source/data/siteids/4.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/40.json
+++ b/Source/data/siteids/40.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -151,7 +151,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/41.json
+++ b/Source/data/siteids/41.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -79,7 +79,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/42.json
+++ b/Source/data/siteids/42.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -139,7 +139,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -161,7 +161,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -227,7 +227,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -357,7 +357,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/43.json
+++ b/Source/data/siteids/43.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -280,7 +280,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -302,7 +302,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -324,7 +324,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -346,7 +346,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -368,7 +368,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -388,7 +388,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -410,7 +410,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -432,7 +432,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -476,7 +476,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -498,7 +498,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/44.json
+++ b/Source/data/siteids/44.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -295,7 +295,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -317,7 +317,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -339,7 +339,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -383,7 +383,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -449,7 +449,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -469,7 +469,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -555,7 +555,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -621,7 +621,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -709,7 +709,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -731,7 +731,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -753,7 +753,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -775,7 +775,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/45.json
+++ b/Source/data/siteids/45.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -129,7 +129,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -303,7 +303,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -325,7 +325,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/46.json
+++ b/Source/data/siteids/46.json
@@ -27,7 +27,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -465,7 +465,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -509,7 +509,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -531,7 +531,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/47.json
+++ b/Source/data/siteids/47.json
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -183,7 +183,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -313,7 +313,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/48.json
+++ b/Source/data/siteids/48.json
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -451,7 +451,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -471,7 +471,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -493,7 +493,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -515,7 +515,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/49.json
+++ b/Source/data/siteids/49.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -83,7 +83,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/5.json
+++ b/Source/data/siteids/5.json
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -213,7 +213,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -411,7 +411,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -433,7 +433,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -455,7 +455,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/50.json
+++ b/Source/data/siteids/50.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -505,7 +505,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/51.json
+++ b/Source/data/siteids/51.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/52.json
+++ b/Source/data/siteids/52.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -225,7 +225,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -269,7 +269,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -335,7 +335,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -487,7 +487,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -531,7 +531,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -551,7 +551,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -595,7 +595,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -617,7 +617,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -639,7 +639,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -681,7 +681,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -703,7 +703,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -725,7 +725,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/53.json
+++ b/Source/data/siteids/53.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -265,7 +265,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/54.json
+++ b/Source/data/siteids/54.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -327,7 +327,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -349,7 +349,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -369,7 +369,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -391,7 +391,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -413,7 +413,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -499,7 +499,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -521,7 +521,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -543,7 +543,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -587,7 +587,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -609,7 +609,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -631,7 +631,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -675,7 +675,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/55.json
+++ b/Source/data/siteids/55.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/56.json
+++ b/Source/data/siteids/56.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -161,7 +161,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -289,7 +289,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/57.json
+++ b/Source/data/siteids/57.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -291,7 +291,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -399,7 +399,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -421,7 +421,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -443,7 +443,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/58.json
+++ b/Source/data/siteids/58.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/59.json
+++ b/Source/data/siteids/59.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 44,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -327,7 +327,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -349,7 +349,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -393,7 +393,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -435,7 +435,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -457,7 +457,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/6.json
+++ b/Source/data/siteids/6.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/60.json
+++ b/Source/data/siteids/60.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -109,7 +109,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -373,7 +373,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -395,7 +395,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -417,7 +417,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -505,7 +505,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/61.json
+++ b/Source/data/siteids/61.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/62.json
+++ b/Source/data/siteids/62.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -177,7 +177,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -243,7 +243,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -309,7 +309,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -353,7 +353,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -397,7 +397,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -483,7 +483,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -505,7 +505,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -527,7 +527,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -549,7 +549,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -571,7 +571,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -593,7 +593,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/63.json
+++ b/Source/data/siteids/63.json
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -379,7 +379,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -401,7 +401,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -478,7 +478,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -500,7 +500,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -522,7 +522,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/64.json
+++ b/Source/data/siteids/64.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/65.json
+++ b/Source/data/siteids/65.json
@@ -87,7 +87,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -175,7 +175,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -197,7 +197,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -415,7 +415,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -437,7 +437,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -459,7 +459,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/66.json
+++ b/Source/data/siteids/66.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -367,7 +367,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -389,7 +389,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/67.json
+++ b/Source/data/siteids/67.json
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/68.json
+++ b/Source/data/siteids/68.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/69.json
+++ b/Source/data/siteids/69.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -81,7 +81,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -103,7 +103,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -145,7 +145,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/7.json
+++ b/Source/data/siteids/7.json
@@ -45,7 +45,7 @@
                 {
                     "activeGroup": {
                         "groupName": "H",
-                        "amount": 7
+                        "amount": 9
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -379,7 +379,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -401,7 +401,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -467,7 +467,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -511,7 +511,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -533,7 +533,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -555,7 +555,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/70.json
+++ b/Source/data/siteids/70.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -97,7 +97,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -183,7 +183,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -205,7 +205,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -227,7 +227,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -249,7 +249,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -271,7 +271,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -293,7 +293,7 @@
                         },
                         "obeliskNumber": 50,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/71.json
+++ b/Source/data/siteids/71.json
@@ -21,19 +21,19 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -113,7 +113,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -135,7 +135,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -155,7 +155,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -241,7 +241,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -325,7 +325,7 @@
                         },
                         "obeliskNumber": 48,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 56,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -411,7 +411,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -455,7 +455,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -499,7 +499,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -521,7 +521,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/72.json
+++ b/Source/data/siteids/72.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -93,7 +93,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -115,7 +115,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -137,7 +137,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -159,7 +159,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -181,7 +181,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -203,7 +203,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -247,7 +247,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -311,7 +311,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -333,7 +333,7 @@
                         },
                         "obeliskNumber": 55,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -377,7 +377,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -419,7 +419,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -441,7 +441,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -463,7 +463,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -485,7 +485,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -507,7 +507,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/73.json
+++ b/Source/data/siteids/73.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/74.json
+++ b/Source/data/siteids/74.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {

--- a/Source/data/siteids/75.json
+++ b/Source/data/siteids/75.json
@@ -57,7 +57,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],
@@ -69,7 +69,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -91,7 +91,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -157,7 +157,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -179,7 +179,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -201,7 +201,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -223,7 +223,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -245,7 +245,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -267,7 +267,7 @@
                         },
                         "obeliskNumber": 43,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"

--- a/Source/data/siteids/76.json
+++ b/Source/data/siteids/76.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 26,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -361,7 +361,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -427,7 +427,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -449,7 +449,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -513,7 +513,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -535,7 +535,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -557,7 +557,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/77.json
+++ b/Source/data/siteids/77.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "C",
-                        "amount": 22
+                        "amount": 25
                     }
                 },
                 {
@@ -63,7 +63,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -107,7 +107,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/78.json
+++ b/Source/data/siteids/78.json
@@ -77,7 +77,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -99,7 +99,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/79.json
+++ b/Source/data/siteids/79.json
@@ -57,7 +57,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -165,7 +165,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/8.json
+++ b/Source/data/siteids/8.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -85,7 +85,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/data/siteids/80.json
+++ b/Source/data/siteids/80.json
@@ -131,7 +131,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -153,7 +153,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -173,7 +173,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -239,7 +239,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -261,7 +261,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -281,7 +281,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -303,7 +303,7 @@
                         },
                         "obeliskNumber": 42,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -347,7 +347,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -369,7 +369,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -391,7 +391,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -413,7 +413,7 @@
                         },
                         "obeliskNumber": 25,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -435,7 +435,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -457,7 +457,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/81.json
+++ b/Source/data/siteids/81.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -277,7 +277,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -453,7 +453,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -475,7 +475,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -497,7 +497,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -519,7 +519,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/82.json
+++ b/Source/data/siteids/82.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -111,7 +111,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -133,7 +133,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -219,7 +219,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -285,7 +285,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -307,7 +307,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -329,7 +329,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -351,7 +351,7 @@
                         },
                         "obeliskNumber": 47,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -461,7 +461,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -549,7 +549,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -571,7 +571,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -593,7 +593,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -615,7 +615,7 @@
                         },
                         "obeliskNumber": 24,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -637,7 +637,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/83.json
+++ b/Source/data/siteids/83.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
@@ -33,7 +33,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -121,7 +121,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -187,7 +187,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -209,7 +209,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -231,7 +231,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -253,7 +253,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -275,7 +275,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -297,7 +297,7 @@
                         },
                         "obeliskNumber": 43,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -341,7 +341,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -451,7 +451,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 22,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 23,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/84.json
+++ b/Source/data/siteids/84.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -199,7 +199,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -221,7 +221,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -263,7 +263,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/85.json
+++ b/Source/data/siteids/85.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -215,7 +215,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 29,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -299,7 +299,7 @@
                         },
                         "obeliskNumber": 49,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -343,7 +343,7 @@
                         },
                         "obeliskNumber": 54,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -385,7 +385,7 @@
                         },
                         "obeliskNumber": 10,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -451,7 +451,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -471,7 +471,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -491,7 +491,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -513,7 +513,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -535,7 +535,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -557,7 +557,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -579,7 +579,7 @@
                         },
                         "obeliskNumber": 21,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -601,7 +601,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/86.json
+++ b/Source/data/siteids/86.json
@@ -125,7 +125,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -147,7 +147,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -169,7 +169,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -233,7 +233,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -255,7 +255,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -319,7 +319,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -363,7 +363,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -407,7 +407,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"

--- a/Source/data/siteids/87.json
+++ b/Source/data/siteids/87.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -105,7 +105,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -127,7 +127,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -149,7 +149,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -171,7 +171,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -193,7 +193,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -235,7 +235,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -257,7 +257,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -279,7 +279,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -301,7 +301,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -323,7 +323,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -345,7 +345,7 @@
                         },
                         "obeliskNumber": 20,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -365,7 +365,7 @@
                         },
                         "obeliskNumber": 37,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -387,7 +387,7 @@
                         },
                         "obeliskNumber": 53,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -409,7 +409,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -473,7 +473,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -495,7 +495,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -517,7 +517,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -539,7 +539,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -561,7 +561,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -583,7 +583,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -605,7 +605,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/88.json
+++ b/Source/data/siteids/88.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 11,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -141,7 +141,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -163,7 +163,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -207,7 +207,7 @@
                         },
                         "obeliskNumber": 16,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -315,7 +315,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 12,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -423,7 +423,7 @@
                         },
                         "obeliskNumber": 15,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -445,7 +445,7 @@
                         },
                         "obeliskNumber": 18,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/89.json
+++ b/Source/data/siteids/89.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 10
                     }
                 },
                 {
@@ -51,7 +51,7 @@
                 {
                     "activeGroup": {
                         "groupName": "U",
-                        "amount": 55
+                        "amount": 57
                     }
                 }
             ],

--- a/Source/data/siteids/9.json
+++ b/Source/data/siteids/9.json
@@ -21,13 +21,13 @@
                 {
                     "activeGroup": {
                         "groupName": "A",
-                        "amount": 0
+                        "amount": 27
                     }
                 },
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 15
+                        "amount": 27
                     }
                 },
                 {
@@ -39,7 +39,7 @@
                 {
                     "activeGroup": {
                         "groupName": "D",
-                        "amount": 15
+                        "amount": 16
                     }
                 },
                 {
@@ -143,7 +143,7 @@
                         },
                         "obeliskNumber": 27,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -185,7 +185,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -447,7 +447,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -553,7 +553,7 @@
                         },
                         "obeliskNumber": 5,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -573,7 +573,7 @@
                         },
                         "obeliskNumber": 13,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -595,7 +595,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -617,7 +617,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -659,7 +659,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -723,7 +723,7 @@
                         },
                         "obeliskNumber": 3,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -745,7 +745,7 @@
                         },
                         "obeliskNumber": 7,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"

--- a/Source/data/siteids/90.json
+++ b/Source/data/siteids/90.json
@@ -75,7 +75,7 @@
                         },
                         "obeliskNumber": 17,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -119,7 +119,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Biology"
@@ -229,7 +229,7 @@
                         },
                         "obeliskNumber": 1,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "History"
@@ -251,7 +251,7 @@
                         },
                         "obeliskNumber": 2,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -273,7 +273,7 @@
                         },
                         "obeliskNumber": 9,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -337,7 +337,7 @@
                         },
                         "obeliskNumber": 4,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -359,7 +359,7 @@
                         },
                         "obeliskNumber": 8,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -381,7 +381,7 @@
                         },
                         "obeliskNumber": 19,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"

--- a/Source/data/siteids/91.json
+++ b/Source/data/siteids/91.json
@@ -21,7 +21,7 @@
                 {
                     "activeGroup": {
                         "groupName": "B",
-                        "amount": 0
+                        "amount": 6
                     }
                 },
                 {
@@ -51,7 +51,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Technology"
@@ -73,7 +73,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Language"
@@ -95,7 +95,7 @@
                         },
                         "obeliskNumber": 6,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"
@@ -117,7 +117,7 @@
                         },
                         "obeliskNumber": 14,
                         "broken": false,
-                        "verified": false,
+                        "verified": true,
                         "grCodexData": {
                             "grCodexCategory": {
                                 "categoryName": "Culture"

--- a/Source/index.html
+++ b/Source/index.html
@@ -260,7 +260,7 @@
 
 				<div id="test-groups" style="background-color: white; display:none"><span>Test Groups</span></div>
 
-				<div id="edbearing" class="button first labeled" title="View Coordinates in ED Bearing"><span>EDbearing</span></div>
+				<!-- <div id="edbearing" class="button first labeled" title="View Coordinates in ED Bearing"><span>EDbearing</span></div>--> 
 
 				<div id="edsm" class="button labeled" title="View System in ED Star Map"><span>ED Star Map</span></div>
 			</div>
@@ -296,24 +296,23 @@
 							The team members are (in alphabetical order):
 								<ul>
 									<li>AdmlAdama (Development Interactive Maps)
-										<a class="logo elite" href="https://forums.frontier.co.uk/member.php/149570-AdmlAdama" target="new"></a>
+										<a class="logo elite" href="https://forums.frontier.co.uk/members/.149570" target="new"></a>
 										<a class="logo github" href="https://github.com/CmdrAdama" target="new"></a>
 									</li>
 									<li>DMehaffy (Infrastructure &amp; Hosting)
-										<a class="logo elite" href="https://forums.frontier.co.uk/member.php/89809-DMehaffy" target="new"></a>
+										<a class="logo elite" href="https://forums.frontier.co.uk/members/.89809" target="new"></a>
 										<a class="logo github" href="https://github.com/derrickmehaffy" target="new"></a>
 										<a class="logo reddit" href="https://www.reddit.com/user/dmehaffy/" target="new"></a>
 									</li>
 									<li>Nopileos (Development API Front and Backend)
-										<a class="logo elite" href="https://forums.frontier.co.uk/member.php/19716-Phoenix" target="new"></a>
-										<a class="logo github" href="https://github.com/sgingter" target="new"></a>
+										<a class="logo elite" href="https://forums.frontier.co.uk/members/.19716" target="new"></a>
 										<a class="logo twitter" href="https://twitter.com/phoenixhawk/" target="new"></a>
 									</li>
 									<li>Noshei (Science &amp; Data)
-										<a class="logo elite" href="https://forums.frontier.co.uk/member.php/73548-Noshei" target="new"></a>
+										<a class="logo elite" href="https://forums.frontier.co.uk/members/.73548" target="new"></a>
 									</li>
 									<li>Zebarmy (Science &amp; Data)
-										<a class="logo elite" href="https://forums.frontier.co.uk/member.php/18113-Zebarmy" target="new"></a>
+										<a class="logo elite" href="https://forums.frontier.co.uk/members/.18113" target="new"></a>
 										<a class="logo github" href="https://github.com/zebarmy" target="new"></a>
 										<a class="logo twitter" href="https://twitter.com/zebarmy/" target="new"></a>
 										<a class="logo reddit" href="https://www.reddit.com/user/Zebarmy/" target="new"></a>
@@ -356,7 +355,7 @@
 							<p>
 								<ul>
 									<li>masCh (Developer of the original Guardian Ruins Map)
-										<a class="logo elite" href="https://forums.frontier.co.uk/member.php/101551-masCh" target="new"></a>
+										<a class="logo elite" href="https://forums.frontier.co.uk/members/.101551" target="new"></a>
 									</li>
 								</ul>
 							</p>

--- a/Source/scripts/ruins.js
+++ b/Source/scripts/ruins.js
@@ -517,18 +517,18 @@ function prepMapUI(completed) {
 		window.ruins.showAll(!this.checked);
 	});
 
-	$("#edbearing").on('click', function () {
-		var desc = window.currentRuin.ruinTypeName + ' Ruin at ' + [
-			window.currentRuin.systemName,
-			window.currentRuin.bodyName,
-		].join(' | ');
-		var lat = window.currentRuin.coordinates[0];
-		var lon = window.currentRuin.coordinates[1];
-
-		var bearingUrl = 'http://hotdoy.ca/ed/bearing/?lat=' + encodeURIComponent(lat) + '&lon=' + encodeURIComponent(lon) + '&title=' + encodeURIComponent(desc);
-
-		window.open(bearingUrl, '_blank');
-	});
+// 	$("#edbearing").on('click', function () {
+// 		var desc = window.currentRuin.ruinTypeName + ' Ruin at ' + [
+// 			window.currentRuin.systemName,
+// 			window.currentRuin.bodyName,
+// 		].join(' | ');
+// 		var lat = window.currentRuin.coordinates[0];
+// 		var lon = window.currentRuin.coordinates[1];
+// 
+// 		var bearingUrl = 'http://hotdoy.ca/ed/bearing/?lat=' + encodeURIComponent(lat) + '&lon=' + encodeURIComponent(lon) + '&title=' + encodeURIComponent(desc);
+// 
+// 		window.open(bearingUrl, '_blank');
+// 	});
 
 	$("#edsm").on('click', function () {
 		var edsmLink = window.currentRuin.edsmBodyLink;


### PR DESCRIPTION
Updated getRuinList + siteids in prep for adding/updating obelisk data

getRuinList:
• Fix typo in id64
• Updated the "obeliskNumber" value for the groups and added missing obelisks:

Alpha:
H: 7 → 9
H: Added H8 (Broken), H9 (Broken)

Beta:
U: 55 → 57
U: Added U20 (Active Obelisk, buried, needed to shift rest of obelisk numbers by 1), U57 (Broken) 
U: Moved 37 (Broken) → 38 (Broken), and 38 (Broken) → 39 (Broken)

Gamma:
D: 15 → 16
D: Added D16 (Broken)

siteids:
• Updated the "amount" value in active groups:

Alpha:
H: 7 → 9

Beta:
A: 0 → 10
B: 0 → 6
C: 22 → 25
U: 55 → 57

Gamma:
A: 0 → 27
B: 15 → 27
D: 15 → 16

---

disabled EDBearing as it no longer works

commented out EDBearing in Index.html and ruins.js as it has not worked since approx. 2019

updated forum links + removed one github link (account no longer exists) in Index.html